### PR TITLE
Add beta support for end of month reminders

### DIFF
--- a/extension/__tests__/service-worker/notification.ts
+++ b/extension/__tests__/service-worker/notification.ts
@@ -1,8 +1,8 @@
 import { describe, expect, jest, test } from '@jest/globals'
-import { TimeSheetDates } from '../../src/types/time-sheet'
-import { shouldNotifyUser } from '../../src/service-worker/notifications'
 import { getExtensionOptions } from '../../src/extension-options/storage'
+import { shouldNotifyUser } from '../../src/service-worker/notifications'
 import { getTimeSheet } from '../../src/time-sheets/storage'
+import { TimeSheetDates } from '../../src/types/time-sheet'
 
 const dates: TimeSheetDates = {
   monday: {
@@ -58,6 +58,7 @@ describe('shouldNotifyUser', () => {
     getExtensionOptionsMock.mockResolvedValue({
       endOfWeekTimesheetReminder: true,
       dailyTimeEntryReminder: false,
+      endOfMonthTimesheetReminder: false,
       gifDataUrl: '',
       soundDataUrl: '',
     })
@@ -90,6 +91,7 @@ describe('shouldNotifyUser', () => {
     getExtensionOptionsMock.mockResolvedValue({
       endOfWeekTimesheetReminder: false,
       dailyTimeEntryReminder: false,
+      endOfMonthTimesheetReminder: false,
       gifDataUrl: '',
       soundDataUrl: '',
     })
@@ -122,6 +124,7 @@ describe('shouldNotifyUser', () => {
     getExtensionOptionsMock.mockResolvedValue({
       endOfWeekTimesheetReminder: false,
       dailyTimeEntryReminder: true,
+      endOfMonthTimesheetReminder: false,
       gifDataUrl: '',
       soundDataUrl: '',
     })
@@ -154,6 +157,7 @@ describe('shouldNotifyUser', () => {
     getExtensionOptionsMock.mockResolvedValue({
       endOfWeekTimesheetReminder: false,
       dailyTimeEntryReminder: true,
+      endOfMonthTimesheetReminder: false,
       gifDataUrl: '',
       soundDataUrl: '',
     })
@@ -186,6 +190,7 @@ describe('shouldNotifyUser', () => {
     getExtensionOptionsMock.mockResolvedValue({
       endOfWeekTimesheetReminder: true,
       dailyTimeEntryReminder: true,
+      endOfMonthTimesheetReminder: false,
       gifDataUrl: '',
       soundDataUrl: '',
     })
@@ -218,6 +223,7 @@ describe('shouldNotifyUser', () => {
     getExtensionOptionsMock.mockResolvedValue({
       endOfWeekTimesheetReminder: true,
       dailyTimeEntryReminder: true,
+      endOfMonthTimesheetReminder: false,
       gifDataUrl: '',
       soundDataUrl: '',
     })
@@ -262,6 +268,7 @@ describe('shouldNotifyUser', () => {
     getExtensionOptionsMock.mockResolvedValue({
       endOfWeekTimesheetReminder: true,
       dailyTimeEntryReminder: true,
+      endOfMonthTimesheetReminder: false,
       gifDataUrl: '',
       soundDataUrl: '',
     })
@@ -300,5 +307,74 @@ describe('shouldNotifyUser', () => {
 
     const actual = await shouldNotifyUser()
     expect(actual).toEqual(false)
+  })
+
+  test('when the last day of the month is in the middle of the week', async () => {
+    getExtensionOptionsMock.mockResolvedValue({
+      endOfWeekTimesheetReminder: false,
+      dailyTimeEntryReminder: false,
+      endOfMonthTimesheetReminder: true,
+      gifDataUrl: '',
+      soundDataUrl: '',
+    })
+
+    getTimeSheetMock.mockResolvedValue({
+      dates: {
+        monday: {
+          year: 2023,
+          month: 5,
+          day: 29,
+        },
+        tuesday: {
+          year: 2023,
+          month: 5,
+          day: 30,
+        },
+        wednesday: {
+          year: 2023,
+          month: 5,
+          day: 31,
+        },
+        thursday: {
+          year: 2023,
+          month: 6,
+          day: 1,
+        },
+        friday: {
+          year: 2023,
+          month: 6,
+          day: 2,
+        },
+        saturday: {
+          year: 2023,
+          month: 6,
+          day: 3,
+        },
+        sunday: {
+          year: 2023,
+          month: 6,
+          day: 4,
+        },
+      },
+      timeCards: [
+        {
+          status: 'saved',
+          hours: {
+            monday: 8,
+            tuesday: 8,
+            wednesday: 8,
+            thursday: 0,
+            friday: 0,
+            saturday: 0,
+            sunday: 0,
+          },
+        },
+      ],
+    })
+
+    jest.useFakeTimers().setSystemTime(new Date(2023, 5, 31, 0, 0, 0))
+
+    const actual = await shouldNotifyUser()
+    expect(actual).toEqual(true)
   })
 })

--- a/extension/__tests__/time-sheets/summary.ts
+++ b/extension/__tests__/time-sheets/summary.ts
@@ -40,6 +40,44 @@ const dates: TimeSheetDates = {
   },
 }
 
+const endOfWeekDates: TimeSheetDates = {
+  monday: {
+    year: 2023,
+    month: 5,
+    day: 29,
+  },
+  tuesday: {
+    year: 2023,
+    month: 5,
+    day: 30,
+  },
+  wednesday: {
+    year: 2023,
+    month: 5,
+    day: 31,
+  },
+  thursday: {
+    year: 2023,
+    month: 6,
+    day: 1,
+  },
+  friday: {
+    year: 2023,
+    month: 6,
+    day: 2,
+  },
+  saturday: {
+    year: 2023,
+    month: 6,
+    day: 3,
+  },
+  sunday: {
+    year: 2023,
+    month: 6,
+    day: 4,
+  },
+}
+
 describe('summarizeTimeSheet', () => {
   beforeAll(() => {
     jest.useFakeTimers().setSystemTime(new Date(2023, 2, 19, 0, 0, 0))
@@ -65,6 +103,7 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '00:00:00',
       weekStatus: 'no-time-cards',
+      alertableLastDayOfMonth: null,
     }
 
     expect(summarizeTimeSheet(emptyTimeSheet)).toEqual(expected)
@@ -103,6 +142,7 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '00:00:00',
       weekStatus: 'some-unsubmitted',
+      alertableLastDayOfMonth: null,
     }
 
     expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
@@ -153,6 +193,7 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 5,
       timeRemaining: '00:00:00',
       weekStatus: 'all-submitted-or-approved',
+      alertableLastDayOfMonth: null,
     }
 
     expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
@@ -203,6 +244,7 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 2,
       timeRemaining: '00:00:00',
       weekStatus: 'some-unsubmitted',
+      alertableLastDayOfMonth: null,
     }
 
     expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
@@ -253,6 +295,7 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 2,
       timeRemaining: '00:00:00',
       weekStatus: 'some-unsubmitted',
+      alertableLastDayOfMonth: null,
     }
 
     expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
@@ -291,6 +334,7 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '00:00:00',
       weekStatus: 'some-unsaved',
+      alertableLastDayOfMonth: null,
     }
 
     expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
@@ -331,6 +375,7 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '25:00:00',
       weekStatus: 'some-unsaved',
+      alertableLastDayOfMonth: null,
     }
 
     expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
@@ -371,6 +416,7 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '00:00:01',
       weekStatus: 'some-unsaved',
+      alertableLastDayOfMonth: null,
     }
 
     expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
@@ -411,6 +457,7 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '00:00:00',
       weekStatus: 'some-unsaved',
+      alertableLastDayOfMonth: null,
     }
 
     expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
@@ -449,6 +496,91 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 5,
       timeRemaining: '00:00:00',
       weekStatus: 'all-submitted-or-approved',
+      alertableLastDayOfMonth: null,
+    }
+
+    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+  })
+
+  test('when the end of the week is wednesday', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 4, 31, 0, 0, 0))
+
+    const timeSheet: TimeSheet = {
+      dates: endOfWeekDates,
+      timeCards: [],
+    }
+
+    const expected: TimeSheetSummary = {
+      daysFilled: {
+        monday: false,
+        tuesday: false,
+        wednesday: false,
+        thursday: false,
+        friday: false,
+        saturday: false,
+        sunday: false,
+      },
+      totalDaysSaved: 0,
+      totalDaysSubmitted: 0,
+      timeRemaining: '17:00:00',
+      weekStatus: 'no-time-cards',
+      alertableLastDayOfMonth: 'wednesday',
+    }
+
+    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+  })
+
+  test('when the end of the week is wednesday + buzzer beater', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 4, 31, 17, 0, 0))
+
+    const timeSheet: TimeSheet = {
+      dates: endOfWeekDates,
+      timeCards: [],
+    }
+
+    const expected: TimeSheetSummary = {
+      daysFilled: {
+        monday: false,
+        tuesday: false,
+        wednesday: false,
+        thursday: false,
+        friday: false,
+        saturday: false,
+        sunday: false,
+      },
+      totalDaysSaved: 0,
+      totalDaysSubmitted: 0,
+      timeRemaining: '00:00:00',
+      weekStatus: 'no-time-cards',
+      alertableLastDayOfMonth: 'wednesday',
+    }
+
+    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+  })
+
+  test('when the end of the week is wednesday + buzzer beater failure', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 4, 31, 17, 0, 1))
+
+    const timeSheet: TimeSheet = {
+      dates: endOfWeekDates,
+      timeCards: [],
+    }
+
+    const expected: TimeSheetSummary = {
+      daysFilled: {
+        monday: false,
+        tuesday: false,
+        wednesday: false,
+        thursday: false,
+        friday: false,
+        saturday: false,
+        sunday: false,
+      },
+      totalDaysSaved: 0,
+      totalDaysSubmitted: 0,
+      timeRemaining: '23:59:59',
+      weekStatus: 'no-time-cards',
+      alertableLastDayOfMonth: 'wednesday',
     }
 
     expect(summarizeTimeSheet(timeSheet)).toEqual(expected)

--- a/extension/package/extension-options.html
+++ b/extension/package/extension-options.html
@@ -8,6 +8,15 @@
   <body>
     <form id="options">
       <label class="row">
+        <p>Daily reminders</p>
+
+        <div class="checkbox-wrapper">
+          <input type="checkbox" id="daily-time-entry-reminder" />
+          <label for="daily-time-entry-reminder" class="toggle"><span></span></label>
+        </div>
+      </label>
+
+      <label class="row">
         <p>End of week reminders</p>
 
         <div class="checkbox-wrapper">
@@ -17,11 +26,11 @@
       </label>
 
       <label class="row">
-        <p>Daily reminders</p>
+        <p>End of month reminders (BETA)</p>
 
         <div class="checkbox-wrapper">
-          <input type="checkbox" id="daily-time-entry-reminder" />
-          <label for="daily-time-entry-reminder" class="toggle"><span></span></label>
+          <input type="checkbox" id="end-of-month-timesheet-reminder" />
+          <label for="end-of-month-timesheet-reminder" class="toggle"><span></span></label>
         </div>
       </label>
 

--- a/extension/src/extension-options.ts
+++ b/extension/src/extension-options.ts
@@ -1,16 +1,18 @@
 import { createGifSelector, getSelectedGifUrl } from './extension-options/gifs'
 import { createSoundSelector, getSelectedSoundUrl } from './extension-options/sounds'
 import { getExtensionOptions } from './extension-options/storage'
+import { ExtensionOptions } from './types/extension-options'
 
 const main = async () => {
   const form = document.getElementById('options') as HTMLFormElement
   const endOfWeekTimesheetReminder = document.getElementById('end-of-week-timesheet-reminder') as HTMLInputElement
   const dailyTimeEntryReminder = document.getElementById('daily-time-entry-reminder') as HTMLInputElement
+  const endOfMonthTimesheetReminder = document.getElementById('end-of-month-timesheet-reminder') as HTMLInputElement
   const versionElement = document.getElementById('version') as HTMLSpanElement
 
   versionElement.innerText = (window as any)['ClockStormVersion'] as string
 
-  if (!form || !endOfWeekTimesheetReminder || !dailyTimeEntryReminder) {
+  if (!form || !endOfWeekTimesheetReminder || !dailyTimeEntryReminder || !endOfMonthTimesheetReminder) {
     throw new Error('Unable to find options form')
   }
 
@@ -21,6 +23,7 @@ const main = async () => {
 
   endOfWeekTimesheetReminder.checked = extensionOptions.endOfWeekTimesheetReminder
   dailyTimeEntryReminder.checked = extensionOptions.dailyTimeEntryReminder
+  endOfMonthTimesheetReminder.checked = extensionOptions.endOfMonthTimesheetReminder
 
   form.addEventListener('submit', async (event) => {
     event.preventDefault()
@@ -28,13 +31,16 @@ const main = async () => {
     const soundDataUrl = await getSelectedSoundUrl(extensionOptions)
     const gifDataUrl = await getSelectedGifUrl(extensionOptions)
 
+    const newExtensionOptions: ExtensionOptions = {
+      soundDataUrl,
+      gifDataUrl,
+      endOfWeekTimesheetReminder: endOfWeekTimesheetReminder.checked,
+      dailyTimeEntryReminder: dailyTimeEntryReminder.checked,
+      endOfMonthTimesheetReminder: endOfMonthTimesheetReminder.checked,
+    }
+
     await chrome.storage.local.set({
-      extensionOptions: {
-        soundDataUrl,
-        gifDataUrl,
-        endOfWeekTimesheetReminder: endOfWeekTimesheetReminder.checked,
-        dailyTimeEntryReminder: dailyTimeEntryReminder.checked,
-      },
+      extensionOptions: newExtensionOptions,
     })
 
     window.close()

--- a/extension/src/extension-options/storage.ts
+++ b/extension/src/extension-options/storage.ts
@@ -13,5 +13,6 @@ export const getExtensionOptions = async (): Promise<ExtensionOptions> => {
     gifDataUrl: 'gifs/clockstorm.gif',
     endOfWeekTimesheetReminder: true,
     dailyTimeEntryReminder: true,
+    endOfMonthTimesheetReminder: true,
   }
 }

--- a/extension/src/service-worker/notifications.ts
+++ b/extension/src/service-worker/notifications.ts
@@ -2,6 +2,7 @@ import { getExtensionOptions } from '../extension-options/storage'
 import { getTimeSheet } from '../time-sheets/storage'
 import { summarizeTimeSheet } from '../time-sheets/summary'
 import {
+  DayOfWeek,
   dayOfWeekIndexes,
   getAllDaysPriorInWeek,
   getDayOfWeek,
@@ -17,6 +18,9 @@ export const shouldNotifyUser = async (): Promise<boolean> => {
   const summary = summarizeTimeSheet(timeSheet)
   const daysPrior = getAllDaysPriorInWeek(dayOfWeek, true, true)
   const extensionOptions = await getExtensionOptions()
+  const dayOfWeekIndex = dayOfWeekIndexes[dayOfWeek]
+  const dueDayOfWeek: DayOfWeek = 'thursday'
+  const dueDayOfWeekIndex = dayOfWeekIndexes[dueDayOfWeek]
 
   for (const dayPrior of daysPrior) {
     if (
@@ -27,12 +31,16 @@ export const shouldNotifyUser = async (): Promise<boolean> => {
     }
   }
 
-  const dayOfWeekIndex = dayOfWeekIndexes[dayOfWeek]
-  const thursdayIndex = dayOfWeekIndexes.thursday
+  if (summary.alertableLastDayOfMonth && extensionOptions.endOfMonthTimesheetReminder) {
+    const alertableLastDayOfMonthIndex = dayOfWeekIndexes[summary.alertableLastDayOfMonth]
+    if (dayOfWeekIndex >= alertableLastDayOfMonthIndex && summary.weekStatus !== 'all-submitted-or-approved') {
+      return true
+    }
+  }
 
   return (
     extensionOptions.endOfWeekTimesheetReminder &&
-    dayOfWeekIndex >= thursdayIndex &&
+    dayOfWeekIndex >= dueDayOfWeekIndex &&
     summary.weekStatus !== 'all-submitted-or-approved'
   )
 }

--- a/extension/src/types/dates.ts
+++ b/extension/src/types/dates.ts
@@ -117,3 +117,9 @@ export const getAllDaysPriorInWeek = (
     return !(onlyBusinessDays && !isBusinessDayOfWeek(singleDayOfWeek))
   })
 }
+
+export const getLastDayOfMonth = (month: number, year: number) => {
+  const date = new Date(year, month - 1, 1)
+  date.setMonth(date.getMonth() + 1, 0)
+  return date.getDate()
+}

--- a/extension/src/types/extension-options.ts
+++ b/extension/src/types/extension-options.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod'
 
 export const ExtensionOptions = z.object({
-  endOfWeekTimesheetReminder: z.boolean(),
-  dailyTimeEntryReminder: z.boolean(),
-  soundDataUrl: z.string(),
-  gifDataUrl: z.string(),
+  endOfWeekTimesheetReminder: z.boolean().default(true),
+  dailyTimeEntryReminder: z.boolean().default(true),
+  endOfMonthTimesheetReminder: z.boolean().default(true),
+  soundDataUrl: z.string().default('sounds/cricket.wav'),
+  gifDataUrl: z.string().default('gifs/clockstorm.gif'),
 })
 export type ExtensionOptions = z.infer<typeof ExtensionOptions>

--- a/extension/src/types/time-sheet.ts
+++ b/extension/src/types/time-sheet.ts
@@ -1,6 +1,6 @@
 import { isEqual } from 'lodash'
 import { z } from 'zod'
-import { DateOnly } from './dates'
+import { DateOnly, DayOfWeek } from './dates'
 
 export const TimeCardStatus = z.union([
   z.literal('submitted'),
@@ -78,4 +78,5 @@ export interface TimeSheetSummary {
   totalDaysSubmitted: number
   totalDaysSaved: number
   timeRemaining: string
+  alertableLastDayOfMonth: DayOfWeek | null
 }


### PR DESCRIPTION
Some organizations require users to submit time cards twice during weeks that split on a month ending. This commit adds experimental support for a notification to be due at 5pm of the day of the month ending.