### PR TITLE
Add additional links to popup and active notification list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Status indicator on the popup page.
+- Buttons on the popup page to navigate to settings, user guide, GitHub, bug report, feature request and Discord.
+- Active notifications list on the popup page.
 
 ## [1.0.0] - 2023-03-28
 

--- a/extension/__tests__/notifications/notifications.ts
+++ b/extension/__tests__/notifications/notifications.ts
@@ -1,6 +1,6 @@
 import { describe, expect, jest, test } from '@jest/globals'
 import { getExtensionOptions } from '../../src/extension-options/storage'
-import { shouldNotifyUser } from '../../src/service-worker/notifications'
+import { getActiveNotificationTypes } from '../../src/notifications/notifications'
 import { getTimeSheet } from '../../src/time-sheets/storage'
 import { TimeSheetDates } from '../../src/types/time-sheet'
 
@@ -53,7 +53,7 @@ jest.mock('../../src/time-sheets/storage', () => ({
 const getExtensionOptionsMock = getExtensionOptions as jest.Mocked<typeof getExtensionOptions>
 const getTimeSheetMock = getTimeSheet as jest.Mocked<typeof getTimeSheet>
 
-describe('shouldNotifyUser', () => {
+describe('getActiveNotificationTypes', () => {
   test('when there are no time cards submitted and it is thursday and the reminder is enabled', async () => {
     getExtensionOptionsMock.mockResolvedValue({
       endOfWeekTimesheetReminder: true,
@@ -83,8 +83,8 @@ describe('shouldNotifyUser', () => {
 
     jest.useFakeTimers().setSystemTime(new Date(2023, 2, 16, 0, 0, 0))
 
-    const actual = await shouldNotifyUser()
-    expect(actual).toEqual(true)
+    const actual = await getActiveNotificationTypes()
+    expect(actual).toEqual(['weekly'])
   })
 
   test('when there are no time cards submitted and it is thursday but the reminder is off', async () => {
@@ -116,8 +116,8 @@ describe('shouldNotifyUser', () => {
 
     jest.useFakeTimers().setSystemTime(new Date(2023, 2, 16, 0, 0, 0))
 
-    const actual = await shouldNotifyUser()
-    expect(actual).toEqual(false)
+    const actual = await getActiveNotificationTypes()
+    expect(actual).toEqual([])
   })
 
   test('when there is no time entered in previous days and the reminder is enabled', async () => {
@@ -149,8 +149,8 @@ describe('shouldNotifyUser', () => {
 
     jest.useFakeTimers().setSystemTime(new Date(2023, 2, 16, 0, 0, 0))
 
-    const actual = await shouldNotifyUser()
-    expect(actual).toEqual(true)
+    const actual = await getActiveNotificationTypes()
+    expect(actual).toEqual(['daily'])
   })
 
   test('when there is time filled in for all days but they are not saved and the reminder is enabled', async () => {
@@ -182,8 +182,8 @@ describe('shouldNotifyUser', () => {
 
     jest.useFakeTimers().setSystemTime(new Date(2023, 2, 17, 0, 0, 0))
 
-    const actual = await shouldNotifyUser()
-    expect(actual).toEqual(true)
+    const actual = await getActiveNotificationTypes()
+    expect(actual).toEqual(['daily'])
   })
 
   test('when there is time filled in for all days and the time card is submitted and the reminders are enabled', async () => {
@@ -215,8 +215,8 @@ describe('shouldNotifyUser', () => {
 
     jest.useFakeTimers().setSystemTime(new Date(2023, 2, 17, 0, 0, 0))
 
-    const actual = await shouldNotifyUser()
-    expect(actual).toEqual(false)
+    const actual = await getActiveNotificationTypes()
+    expect(actual).toEqual([])
   })
 
   test('when there is time filled in for all days between two time cards but the time cards are not submitted and the reminders are enabled', async () => {
@@ -260,8 +260,8 @@ describe('shouldNotifyUser', () => {
 
     jest.useFakeTimers().setSystemTime(new Date(2023, 2, 17, 0, 0, 0))
 
-    const actual = await shouldNotifyUser()
-    expect(actual).toEqual(true)
+    const actual = await getActiveNotificationTypes()
+    expect(actual).toEqual(['weekly'])
   })
 
   test('when there is time filled in for all days between two time cards and the time cards are submitted and the reminders are enabled', async () => {
@@ -305,8 +305,8 @@ describe('shouldNotifyUser', () => {
 
     jest.useFakeTimers().setSystemTime(new Date(2023, 2, 17, 0, 0, 0))
 
-    const actual = await shouldNotifyUser()
-    expect(actual).toEqual(false)
+    const actual = await getActiveNotificationTypes()
+    expect(actual).toEqual([])
   })
 
   test('when the last day of the month is in the middle of the week', async () => {
@@ -374,7 +374,63 @@ describe('shouldNotifyUser', () => {
 
     jest.useFakeTimers().setSystemTime(new Date(2023, 5, 31, 0, 0, 0))
 
-    const actual = await shouldNotifyUser()
-    expect(actual).toEqual(true)
+    const actual = await getActiveNotificationTypes()
+    expect(actual).toEqual(['monthly'])
+  })
+
+  test('when the user has no days clocked at the end of the week', async () => {
+    getExtensionOptionsMock.mockResolvedValue({
+      endOfWeekTimesheetReminder: true,
+      dailyTimeEntryReminder: true,
+      endOfMonthTimesheetReminder: true,
+      gifDataUrl: '',
+      soundDataUrl: '',
+    })
+
+    getTimeSheetMock.mockResolvedValue({
+      dates: {
+        monday: {
+          year: 2023,
+          month: 5,
+          day: 29,
+        },
+        tuesday: {
+          year: 2023,
+          month: 5,
+          day: 30,
+        },
+        wednesday: {
+          year: 2023,
+          month: 5,
+          day: 31,
+        },
+        thursday: {
+          year: 2023,
+          month: 6,
+          day: 1,
+        },
+        friday: {
+          year: 2023,
+          month: 6,
+          day: 2,
+        },
+        saturday: {
+          year: 2023,
+          month: 6,
+          day: 3,
+        },
+        sunday: {
+          year: 2023,
+          month: 6,
+          day: 4,
+        },
+      },
+      timeCards: [],
+    })
+
+    jest.useFakeTimers().setSystemTime(new Date(2023, 5, 31, 0, 0, 0))
+
+    const actual = await getActiveNotificationTypes()
+    expect(actual).toEqual(['daily', 'weekly', 'monthly'])
   })
 })

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -6,27 +6,60 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   </head>
   <body>
-    <div class="clockstorm-popup-flex-container">
-      <div class="clockstorm-logo-container">
-        <img src="images/logo32.png" alt="Clock Storm" />
-        <i class="status fa-solid fa-check"></i>
-      </div>
-      <div class="clockstorm-timesheet-summary">
+    <div id="popup">
+      <div id="summary" class="hidden">
         <h2>Time Sheet Summary</h2>
-        <div id="summary">
-          <p><span id="timecard-days-saved" class="timecard-dynamic-value"></span> days saved</p>
-          <p><span id="timecard-days-submitted" class="timecard-dynamic-value"></span> days submitted</p>
-          <p>
-            <span id="timecard-time-left" class="timecard-dynamic-value"></span> time left to finish your time cards!
-          </p>
-        </div>
-        <div id="loading">
-          <p>Loading...</p>
+
+        <div class="row">
+          <div class="left">
+            <img src="images/logo32.png" alt="Clock Storm" />
+          </div>
+          <div class="right">
+            <p><span id="timecard-days-saved" class="timecard-dynamic-value"></span> days saved</p>
+            <p><span id="timecard-days-submitted" class="timecard-dynamic-value"></span> days submitted</p>
+            <p>
+              <span id="timecard-time-left" class="timecard-dynamic-value"></span> time left to finish your time cards!
+            </p>
+          </div>
         </div>
       </div>
-    </div>
-    <div id="links">
-      <p><a href="https://github.com/clockstorm/clockstorm" target="_blank">GitHub for support</a></p>
+
+      <div id="active-notifications" class="hidden">
+        <h2>Active Notifications</h2>
+        <div class="row">
+          <div class="left">
+            <i class="status fa-solid fa-triangle-exclamation"></i>
+          </div>
+          <div class="right">
+            <ul></ul>
+          </div>
+        </div>
+        <p>To clear your active notification, navigate to your time sheet and proceed.</p>
+      </div>
+
+      <div id="loading">
+        <p><i class="fa-solid fa-spinner fa-spin" title="Loading"></i></p>
+      </div>
+
+      <div id="links">
+        <p class="settings">
+          <a href="#" id="settings-link" title="Settings"><i class="fa-solid fa-gear"></i></a>
+        </p>
+        <p class="guide">
+          <a href="https://www.clockstorm.com/#guide" title="User Guide" target="_blank"><i class="fa-solid fa-book"></i></a>
+        </p>
+        <p class="github">
+          <a href="https://github.com/clockstorm/clockstorm" title="GitHub" target="_blank"><i class="fa-brands fa-github"></i></a>
+        </p>
+        <p class="bug">
+          <a href="https://github.com/ClockStorm/clockstorm/issues/new?template=bug_report.md" title="Bug Report" target="_blank"><i class="fa-solid fa-bug"></i></a>
+        </p>
+        <p class="idea">
+          <a href="https://github.com/ClockStorm/clockstorm/issues/new?template=feature_request.md" title="Feature Request" target="_blank"><i class="fa-solid fa-lightbulb"></i></a>
+        </p>
+        <p class="discord">
+          <a href="https://discord.com/invite/xSmDZGcZjd" title="Discord" target="_blank"><i class="fa-brands fa-discord"></i></a>
+        </p>
     </div>
   </body>
 </html>

--- a/extension/src/popup/popup.scss
+++ b/extension/src/popup/popup.scss
@@ -14,40 +14,96 @@ h5,
 h6,
 p,
 label,
-span {
+span,
+li {
   font-family: Roboto, system-ui, sans-serif;
 }
 
-h2 {
-  font-weight: bold;
+#summary,
+#active-notifications {
+  line-height: 1.5em;
   font-size: 14px;
-}
-.timecard-dynamic-value {
-  color: red;
+
+  h2 {
+    font-weight: bold;
+    font-size: 14px;
+  }
+
+  .timecard-dynamic-value {
+    color: red;
+    font-weight: bold;
+  }
+
+  .row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 10px;
+
+    .left {
+      font-size: 0;
+      line-height: 0;
+      margin-right: 20px;
+    }
+
+    .right {
+      flex: 1;
+    }
+  }
 }
 
-#summary {
-  line-height: 1.2em;
+.hidden {
   display: none;
 }
 
-.clockstorm-popup-flex-container {
-  display: flex;
-  align-items: center;
+#active-notifications {
+  margin-top: 10px;
+
+  .status {
+    font-size: 32px;
+    color: red;
+  }
+
+  p {
+    font-size: 11px;
+    color: #4b0cf5;
+  }
+
+  ul {
+    font-size: 13px;
+    font-weight: bold;
+    line-height: 1.3em;
+    color: red;
+  }
 }
 
-.clockstorm-popup-flex-container .clockstorm-logo-container {
-  display: inline-flex;
-  flex: 0.5;
-  flex-direction: column;
-  align-items: center;
+#links {
+  text-align: center;
+  margin-top: 10px;
+
+  p {
+    display: inline-block;
+    margin-right: 10px;
+
+    a,
+    a:visited,
+    a:active,
+    a:hover {
+      font-weight: bold;
+      font-size: 28px;
+      color: black;
+      text-decoration: none;
+    }
+  }
 }
 
-.clockstorm-popup-flex-container .clockstorm-timesheet-summary {
-  flex: 3;
-}
+#loading {
+  text-align: center;
+  margin-top: 10px;
+  margin-bottom: 10px;
 
-.clockstorm-popup-flex-container .clockstorm-logo-container .status {
-  font-size: 32px;
-  color: green;
+  i {
+    font-size: 28px;
+    color: black;
+  }
 }

--- a/extension/src/service-worker.ts
+++ b/extension/src/service-worker.ts
@@ -2,8 +2,8 @@ import { animatedIcon } from './background-tasks/animated-icon'
 import { executeBackgroundTask } from './background-tasks/background-task'
 import { getExtensionOptions } from './extension-options/storage'
 import { GIFStream, parseGIF } from './gifs/gifs'
+import { getActiveNotificationTypes } from './notifications/notifications'
 import { playAudio, stopAudio } from './offscreen/offscreen'
-import { shouldNotifyUser } from './service-worker/notifications'
 import { GIF } from './types/gifs'
 import { waitFor } from './utils/utils'
 
@@ -28,7 +28,8 @@ const main = async () => {
   while (true) {
     await waitFor(50)
 
-    const shouldNotify = await shouldNotifyUser()
+    const activeNotificationTypes = await getActiveNotificationTypes()
+    const shouldNotify = activeNotificationTypes.length > 0
 
     const cancelSound = async () => {
       if (soundPlayingId) {


### PR DESCRIPTION
- Buttons on the popup page to navigate to settings, user guide, GitHub, bug report, feature request and Discord.
- Active notifications list on the popup page.

In order to support the active notifications list, we have refactored the notifications logic to output a list of active notification types rather than a boolean.

Fixes #8