### PR TITLE
Add support for selecting granular timing detail for reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [1.2.0] - TBD
 
+### Added
+
+- Support for setting daily reminder days of the week and start time for reminders.
+- Support for setting end of week reminder due date and time, as well as start time for reminders.
+- Support for setting end of week reminder due time, as well as start time for reminders.
+- Users can now browse their time sheet summary for past weeks.
+
+### Changed
+
+- Options screen is now split up into tabs: "General", "Timing", "Alert".
+- Reminders will occur for previous weeks of missing time sheet information (bounded by the installation date of the extension).
+
 ## [1.1.0] - 2023-03-29
 
 ### Added

--- a/clockstorm.code-workspace
+++ b/clockstorm.code-workspace
@@ -33,7 +33,7 @@
       "editor.tabSize": 2
     },
     "emmet.showSuggestionsAsSnippets": true,
-    "cSpell.words": [],
+    "cSpell.words": ["alertable"],
     "typescript.tsdk": "./extension/node_modules/typescript/lib",
     "files.exclude": {
       "**/.git": true,

--- a/extension/__tests__/extension-options/storage.ts
+++ b/extension/__tests__/extension-options/storage.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, test } from '@jest/globals'
+import { getExtensionOptions } from '../../src/extension-options/storage'
+import { ExtensionOptions } from '../../src/types/extension-options'
+import { createMockLocalStorage, installMockLocalStorage } from '../mocks/mock.chrome-local-storage'
+
+const mockLocalStorage = createMockLocalStorage()
+installMockLocalStorage(mockLocalStorage)
+
+const defaultExtensionOptions: ExtensionOptions = {
+  dailyTimeEntryReminder: true,
+  endOfMonthTimesheetReminder: true,
+  endOfWeekTimesheetReminder: true,
+  gifDataUrl: 'gifs/clockstorm.gif',
+  soundDataUrl: 'sounds/cricket.wav',
+  dailyReminderDaysOfWeek: ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'],
+  dailyReminderStartTime: {
+    hour: 9,
+    minute: 0,
+  },
+  endOfWeekReminderDayOfWeek: 'thursday',
+  endOfWeekReminderStartTime: {
+    hour: 9,
+    minute: 0,
+  },
+  endOfWeekReminderDueTime: {
+    hour: 17,
+    minute: 0,
+  },
+  endOfMonthReminderStartTime: {
+    hour: 9,
+    minute: 0,
+  },
+  endOfMonthReminderDueTime: {
+    hour: 17,
+    minute: 0,
+  },
+}
+
+describe('getExtensionOptions', () => {
+  beforeEach(async () => {
+    await mockLocalStorage.clear()
+  })
+
+  test('returns all defaults when nothing is in storage', async () => {
+    const actual = await getExtensionOptions()
+    expect(actual).toEqual(defaultExtensionOptions)
+  })
+
+  test('returns defaults when an incompatible version is in storage', async () => {
+    await mockLocalStorage.set({
+      extensionOptions: {
+        dailyTimeEntryReminder: 5,
+      },
+    })
+
+    const actual = await getExtensionOptions()
+    expect(actual).toEqual(defaultExtensionOptions)
+  })
+
+  test('returns supplemented defaults when an older version is in storage', async () => {
+    await mockLocalStorage.set({
+      extensionOptions: {
+        dailyTimeEntryReminder: false,
+        endOfMonthTimesheetReminder: true,
+        endOfWeekTimesheetReminder: false,
+        gifDataUrl: 'foo',
+        soundDataUrl: 'sounds/rooster.wav',
+      },
+    })
+
+    const actual = await getExtensionOptions()
+    expect(actual).toEqual({
+      ...defaultExtensionOptions,
+      dailyTimeEntryReminder: false,
+      endOfMonthTimesheetReminder: true,
+      endOfWeekTimesheetReminder: false,
+      gifDataUrl: 'foo',
+      soundDataUrl: 'sounds/rooster.wav',
+    })
+  })
+})

--- a/extension/__tests__/installation/helpers.ts
+++ b/extension/__tests__/installation/helpers.ts
@@ -1,0 +1,56 @@
+import { beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals'
+import { getEveryMondaySinceInstallation } from '../../src/installation/helpers'
+import { DateOnly } from '../../src/types/dates'
+import { createMockLocalStorage, installMockLocalStorage } from '../mocks/mock.chrome-local-storage'
+
+const mockLocalStorage = createMockLocalStorage()
+installMockLocalStorage(mockLocalStorage)
+
+describe('getEveryMondaySinceInstallation', () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 3, 9, 9, 0, 0))
+  })
+
+  beforeEach(async () => {
+    await mockLocalStorage.clear()
+  })
+
+  test('returns this monday only if it was installed today', async () => {
+    const actual = await getEveryMondaySinceInstallation()
+    const expected: DateOnly[] = [
+      {
+        year: 2023,
+        month: 4,
+        day: 3,
+      },
+    ]
+
+    expect(actual).toEqual(expected)
+  })
+
+  test('returns this monday and last monday if it was installed last week', async () => {
+    await mockLocalStorage.set({
+      installationDate: {
+        year: 2023,
+        month: 3,
+        day: 30,
+      },
+    })
+
+    const actual = await getEveryMondaySinceInstallation()
+    const expected: DateOnly[] = [
+      {
+        year: 2023,
+        month: 4,
+        day: 3,
+      },
+      {
+        year: 2023,
+        month: 3,
+        day: 27,
+      },
+    ]
+
+    expect(actual).toEqual(expected)
+  })
+})

--- a/extension/__tests__/installation/storage.ts
+++ b/extension/__tests__/installation/storage.ts
@@ -1,0 +1,62 @@
+import { beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals'
+import { getInstallationDate } from '../../src/installation/storage'
+import { DateOnly } from '../../src/types/dates'
+import { createMockLocalStorage, installMockLocalStorage } from '../mocks/mock.chrome-local-storage'
+
+const mockLocalStorage = createMockLocalStorage()
+installMockLocalStorage(mockLocalStorage)
+
+describe('getInstallationDate', () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 3, 9, 9, 0, 0))
+  })
+
+  beforeEach(async () => {
+    await mockLocalStorage.clear()
+  })
+
+  test('returns current date if there is not an installation date stored', async () => {
+    const actual = await getInstallationDate()
+    const expected: DateOnly = {
+      year: 2023,
+      month: 4,
+      day: 9,
+    }
+
+    expect(actual).toEqual(expected)
+  })
+
+  test('returns stored date if there is an installation date stored', async () => {
+    await mockLocalStorage.set({
+      installationDate: {
+        year: 2023,
+        month: 1,
+        day: 2,
+      },
+    })
+
+    const actual = await getInstallationDate()
+    const expected: DateOnly = {
+      year: 2023,
+      month: 1,
+      day: 2,
+    }
+
+    expect(actual).toEqual(expected)
+  })
+
+  test('returns today if there is an installation date stored but it can not be parsed', async () => {
+    await mockLocalStorage.set({
+      installationDate: 'hello',
+    })
+
+    const actual = await getInstallationDate()
+    const expected: DateOnly = {
+      year: 2023,
+      month: 4,
+      day: 9,
+    }
+
+    expect(actual).toEqual(expected)
+  })
+})

--- a/extension/__tests__/mocks/mock.chrome-local-storage.ts
+++ b/extension/__tests__/mocks/mock.chrome-local-storage.ts
@@ -1,0 +1,55 @@
+type GetResult = { [key: string]: any }
+type MockLocalStorage = {
+  get: (keys: string | string[] | null) => Promise<GetResult>
+  set: (items: { [key: string]: any }) => Promise<void>
+  clear: () => Promise<void>
+}
+
+export const createMockLocalStorage = (): MockLocalStorage => {
+  const store: { [key: string]: any } = {}
+
+  const get = async (keys: string[]): Promise<GetResult> => {
+    let anyFound = false
+    const result: GetResult = {}
+
+    for (const key of keys) {
+      if (Object.prototype.hasOwnProperty.call(store, key)) {
+        anyFound = true
+        result[key] = store[key]
+      }
+    }
+
+    if (anyFound) {
+      return result
+    }
+
+    return {}
+  }
+
+  const set = async (items: { [key: string]: any }): Promise<void> => {
+    for (const key of Object.keys(items)) {
+      store[key] = items[key]
+    }
+  }
+
+  const clear = async (): Promise<void> => {
+    for (const key of Object.keys(store)) {
+      delete store[key]
+    }
+  }
+
+  return {
+    get,
+    set,
+    clear,
+  }
+}
+
+export const installMockLocalStorage = (mockLocalStorage: MockLocalStorage) => {
+  const a = globalThis as any
+  a.chrome = {
+    storage: {
+      local: mockLocalStorage,
+    },
+  }
+}

--- a/extension/__tests__/notifications/notifications.ts
+++ b/extension/__tests__/notifications/notifications.ts
@@ -1,8 +1,10 @@
 import { describe, expect, jest, test } from '@jest/globals'
-import { getExtensionOptions } from '../../src/extension-options/storage'
-import { getActiveNotificationTypes } from '../../src/notifications/notifications'
-import { getTimeSheet } from '../../src/time-sheets/storage'
-import { TimeSheetDates } from '../../src/types/time-sheet'
+import { checkShouldNotify, getActiveNotificationTypes } from '../../src/notifications/notifications'
+import { summarizeTimeSheet } from '../../src/time-sheets/summary'
+import { DateOnly } from '../../src/types/dates'
+import { ExtensionOptions } from '../../src/types/extension-options'
+import { TimeSheet, TimeSheetDates } from '../../src/types/time-sheet'
+import { createMockLocalStorage, installMockLocalStorage } from '../mocks/mock.chrome-local-storage'
 
 const dates: TimeSheetDates = {
   monday: {
@@ -42,61 +44,118 @@ const dates: TimeSheetDates = {
   },
 }
 
-jest.mock('../../src/extension-options/storage', () => ({
-  getExtensionOptions: jest.fn(),
-}))
+const endOfMonthDates: TimeSheetDates = {
+  monday: {
+    year: 2023,
+    month: 5,
+    day: 29,
+  },
+  tuesday: {
+    year: 2023,
+    month: 5,
+    day: 30,
+  },
+  wednesday: {
+    year: 2023,
+    month: 5,
+    day: 31,
+  },
+  thursday: {
+    year: 2023,
+    month: 6,
+    day: 1,
+  },
+  friday: {
+    year: 2023,
+    month: 6,
+    day: 2,
+  },
+  saturday: {
+    year: 2023,
+    month: 6,
+    day: 3,
+  },
+  sunday: {
+    year: 2023,
+    month: 6,
+    day: 4,
+  },
+}
 
-jest.mock('../../src/time-sheets/storage', () => ({
-  getTimeSheet: jest.fn(),
-}))
-
-const getExtensionOptionsMock = getExtensionOptions as jest.Mocked<typeof getExtensionOptions>
-const getTimeSheetMock = getTimeSheet as jest.Mocked<typeof getTimeSheet>
+const defaultExtensionOptions: ExtensionOptions = {
+  dailyTimeEntryReminder: true,
+  endOfMonthTimesheetReminder: true,
+  endOfWeekTimesheetReminder: true,
+  gifDataUrl: 'gifs/clockstorm.gif',
+  soundDataUrl: 'sounds/cricket.wav',
+  dailyReminderDaysOfWeek: ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'],
+  dailyReminderStartTime: {
+    hour: 9,
+    minute: 0,
+  },
+  endOfWeekReminderDayOfWeek: 'thursday',
+  endOfWeekReminderStartTime: {
+    hour: 9,
+    minute: 0,
+  },
+  endOfWeekReminderDueTime: {
+    hour: 17,
+    minute: 0,
+  },
+  endOfMonthReminderStartTime: {
+    hour: 9,
+    minute: 0,
+  },
+  endOfMonthReminderDueTime: {
+    hour: 17,
+    minute: 0,
+  },
+}
 
 describe('getActiveNotificationTypes', () => {
   test('when there are no time cards submitted and it is thursday and the reminder is enabled', async () => {
-    getExtensionOptionsMock.mockResolvedValue({
+    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 16, 9, 0, 0))
+
+    const timeSheet: TimeSheet = {
+      dates,
+      timeCards: [
+        {
+          status: 'saved',
+          hours: {
+            monday: 8,
+            tuesday: 8,
+            wednesday: 8,
+            thursday: 8,
+            friday: 8,
+            saturday: 0,
+            sunday: 0,
+          },
+        },
+      ],
+    }
+
+    const extensionOptions: ExtensionOptions = {
+      ...defaultExtensionOptions,
       endOfWeekTimesheetReminder: true,
       dailyTimeEntryReminder: false,
       endOfMonthTimesheetReminder: false,
-      gifDataUrl: '',
-      soundDataUrl: '',
-    })
+    }
 
-    getTimeSheetMock.mockResolvedValue({
-      dates,
-      timeCards: [
-        {
-          status: 'saved',
-          hours: {
-            monday: 8,
-            tuesday: 8,
-            wednesday: 8,
-            thursday: 8,
-            friday: 8,
-            saturday: 0,
-            sunday: 0,
-          },
-        },
-      ],
-    })
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
 
-    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 16, 0, 0, 0))
+    const actual = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
 
-    const actual = await getActiveNotificationTypes()
-    expect(actual).toEqual(['weekly'])
+    expect(actual).toEqual([
+      {
+        type: 'end-of-week',
+      },
+    ])
   })
 
   test('when there are no time cards submitted and it is thursday but the reminder is off', async () => {
-    getExtensionOptionsMock.mockResolvedValue({
-      endOfWeekTimesheetReminder: false,
-      dailyTimeEntryReminder: false,
-      endOfMonthTimesheetReminder: false,
-      gifDataUrl: '',
-      soundDataUrl: '',
-    })
+    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 16, 0, 0, 0))
 
-    getTimeSheetMock.mockResolvedValue({
+    const timeSheet: TimeSheet = {
       dates,
       timeCards: [
         {
@@ -112,24 +171,25 @@ describe('getActiveNotificationTypes', () => {
           },
         },
       ],
-    })
+    }
 
-    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 16, 0, 0, 0))
+    const extensionOptions: ExtensionOptions = {
+      ...defaultExtensionOptions,
+      endOfWeekTimesheetReminder: false,
+      dailyTimeEntryReminder: false,
+      endOfMonthTimesheetReminder: false,
+    }
 
-    const actual = await getActiveNotificationTypes()
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
+
+    const actual = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
     expect(actual).toEqual([])
   })
 
   test('when there is no time entered in previous days and the reminder is enabled', async () => {
-    getExtensionOptionsMock.mockResolvedValue({
-      endOfWeekTimesheetReminder: false,
-      dailyTimeEntryReminder: true,
-      endOfMonthTimesheetReminder: false,
-      gifDataUrl: '',
-      soundDataUrl: '',
-    })
+    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 16, 9, 0, 0))
 
-    getTimeSheetMock.mockResolvedValue({
+    const timeSheet: TimeSheet = {
       dates,
       timeCards: [
         {
@@ -145,24 +205,35 @@ describe('getActiveNotificationTypes', () => {
           },
         },
       ],
-    })
+    }
 
-    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 16, 0, 0, 0))
-
-    const actual = await getActiveNotificationTypes()
-    expect(actual).toEqual(['daily'])
-  })
-
-  test('when there is time filled in for all days but they are not saved and the reminder is enabled', async () => {
-    getExtensionOptionsMock.mockResolvedValue({
+    const extensionOptions: ExtensionOptions = {
+      ...defaultExtensionOptions,
       endOfWeekTimesheetReminder: false,
       dailyTimeEntryReminder: true,
       endOfMonthTimesheetReminder: false,
-      gifDataUrl: '',
-      soundDataUrl: '',
-    })
+    }
 
-    getTimeSheetMock.mockResolvedValue({
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
+
+    const actual = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
+
+    expect(actual).toEqual([
+      {
+        type: 'daily',
+        dayOfWeek: 'wednesday',
+      },
+      {
+        type: 'daily',
+        dayOfWeek: 'thursday',
+      },
+    ])
+  })
+
+  test('when there is time filled in for all days but they are not saved and the reminder is enabled', async () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 17, 9, 0, 0))
+
+    const timeSheet: TimeSheet = {
       dates,
       timeCards: [
         {
@@ -178,24 +249,47 @@ describe('getActiveNotificationTypes', () => {
           },
         },
       ],
-    })
+    }
 
-    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 17, 0, 0, 0))
+    const extensionOptions: ExtensionOptions = {
+      ...defaultExtensionOptions,
+      endOfWeekTimesheetReminder: false,
+      dailyTimeEntryReminder: true,
+      endOfMonthTimesheetReminder: false,
+    }
 
-    const actual = await getActiveNotificationTypes()
-    expect(actual).toEqual(['daily'])
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
+
+    const actual = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
+
+    expect(actual).toEqual([
+      {
+        type: 'daily',
+        dayOfWeek: 'monday',
+      },
+      {
+        type: 'daily',
+        dayOfWeek: 'tuesday',
+      },
+      {
+        type: 'daily',
+        dayOfWeek: 'wednesday',
+      },
+      {
+        type: 'daily',
+        dayOfWeek: 'thursday',
+      },
+      {
+        type: 'daily',
+        dayOfWeek: 'friday',
+      },
+    ])
   })
 
   test('when there is time filled in for all days and the time card is submitted and the reminders are enabled', async () => {
-    getExtensionOptionsMock.mockResolvedValue({
-      endOfWeekTimesheetReminder: true,
-      dailyTimeEntryReminder: true,
-      endOfMonthTimesheetReminder: false,
-      gifDataUrl: '',
-      soundDataUrl: '',
-    })
+    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 17, 0, 0, 0))
 
-    getTimeSheetMock.mockResolvedValue({
+    const timeSheet: TimeSheet = {
       dates,
       timeCards: [
         {
@@ -211,24 +305,25 @@ describe('getActiveNotificationTypes', () => {
           },
         },
       ],
-    })
+    }
 
-    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 17, 0, 0, 0))
+    const extensionOptions: ExtensionOptions = {
+      ...defaultExtensionOptions,
+      endOfWeekTimesheetReminder: true,
+      dailyTimeEntryReminder: true,
+      endOfMonthTimesheetReminder: false,
+    }
 
-    const actual = await getActiveNotificationTypes()
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
+
+    const actual = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
     expect(actual).toEqual([])
   })
 
   test('when there is time filled in for all days between two time cards but the time cards are not submitted and the reminders are enabled', async () => {
-    getExtensionOptionsMock.mockResolvedValue({
-      endOfWeekTimesheetReminder: true,
-      dailyTimeEntryReminder: true,
-      endOfMonthTimesheetReminder: false,
-      gifDataUrl: '',
-      soundDataUrl: '',
-    })
+    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 17, 9, 0, 0))
 
-    getTimeSheetMock.mockResolvedValue({
+    const timeSheet: TimeSheet = {
       dates,
       timeCards: [
         {
@@ -256,24 +351,29 @@ describe('getActiveNotificationTypes', () => {
           },
         },
       ],
-    })
+    }
 
-    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 17, 0, 0, 0))
+    const extensionOptions: ExtensionOptions = {
+      ...defaultExtensionOptions,
+      endOfWeekTimesheetReminder: true,
+      dailyTimeEntryReminder: true,
+      endOfMonthTimesheetReminder: false,
+    }
 
-    const actual = await getActiveNotificationTypes()
-    expect(actual).toEqual(['weekly'])
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
+
+    const actual = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
+    expect(actual).toEqual([
+      {
+        type: 'end-of-week',
+      },
+    ])
   })
 
   test('when there is time filled in for all days between two time cards and the time cards are submitted and the reminders are enabled', async () => {
-    getExtensionOptionsMock.mockResolvedValue({
-      endOfWeekTimesheetReminder: true,
-      dailyTimeEntryReminder: true,
-      endOfMonthTimesheetReminder: false,
-      gifDataUrl: '',
-      soundDataUrl: '',
-    })
+    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 17, 0, 0, 0))
 
-    getTimeSheetMock.mockResolvedValue({
+    const timeSheet: TimeSheet = {
       dates,
       timeCards: [
         {
@@ -301,61 +401,26 @@ describe('getActiveNotificationTypes', () => {
           },
         },
       ],
-    })
+    }
 
-    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 17, 0, 0, 0))
+    const extensionOptions: ExtensionOptions = {
+      ...defaultExtensionOptions,
+      endOfWeekTimesheetReminder: true,
+      dailyTimeEntryReminder: true,
+      endOfMonthTimesheetReminder: false,
+    }
 
-    const actual = await getActiveNotificationTypes()
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
+
+    const actual = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
     expect(actual).toEqual([])
   })
 
   test('when the last day of the month is in the middle of the week', async () => {
-    getExtensionOptionsMock.mockResolvedValue({
-      endOfWeekTimesheetReminder: false,
-      dailyTimeEntryReminder: false,
-      endOfMonthTimesheetReminder: true,
-      gifDataUrl: '',
-      soundDataUrl: '',
-    })
+    jest.useFakeTimers().setSystemTime(new Date(2023, 4, 31, 9, 0, 0))
 
-    getTimeSheetMock.mockResolvedValue({
-      dates: {
-        monday: {
-          year: 2023,
-          month: 5,
-          day: 29,
-        },
-        tuesday: {
-          year: 2023,
-          month: 5,
-          day: 30,
-        },
-        wednesday: {
-          year: 2023,
-          month: 5,
-          day: 31,
-        },
-        thursday: {
-          year: 2023,
-          month: 6,
-          day: 1,
-        },
-        friday: {
-          year: 2023,
-          month: 6,
-          day: 2,
-        },
-        saturday: {
-          year: 2023,
-          month: 6,
-          day: 3,
-        },
-        sunday: {
-          year: 2023,
-          month: 6,
-          day: 4,
-        },
-      },
+    const timeSheet: TimeSheet = {
+      dates: endOfMonthDates,
       timeCards: [
         {
           status: 'saved',
@@ -370,67 +435,399 @@ describe('getActiveNotificationTypes', () => {
           },
         },
       ],
-    })
+    }
 
-    jest.useFakeTimers().setSystemTime(new Date(2023, 5, 31, 0, 0, 0))
+    const extensionOptions: ExtensionOptions = {
+      ...defaultExtensionOptions,
+      endOfWeekTimesheetReminder: false,
+      dailyTimeEntryReminder: false,
+      endOfMonthTimesheetReminder: true,
+    }
 
-    const actual = await getActiveNotificationTypes()
-    expect(actual).toEqual(['monthly'])
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
+
+    const actual = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
+    expect(actual).toEqual([
+      {
+        type: 'end-of-month',
+      },
+    ])
   })
 
   test('when the user has no days clocked at the end of the week', async () => {
-    getExtensionOptionsMock.mockResolvedValue({
+    jest.useFakeTimers().setSystemTime(new Date(2023, 5, 2, 9, 0, 0))
+
+    const timeSheet: TimeSheet = {
+      dates: endOfMonthDates,
+      timeCards: [],
+    }
+
+    const extensionOptions: ExtensionOptions = {
+      ...defaultExtensionOptions,
       endOfWeekTimesheetReminder: true,
       dailyTimeEntryReminder: true,
       endOfMonthTimesheetReminder: true,
-      gifDataUrl: '',
-      soundDataUrl: '',
-    })
+    }
 
-    getTimeSheetMock.mockResolvedValue({
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
+
+    const actual = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
+
+    expect(actual).toEqual([
+      {
+        type: 'daily',
+        dayOfWeek: 'monday',
+      },
+      {
+        type: 'daily',
+        dayOfWeek: 'tuesday',
+      },
+      {
+        type: 'daily',
+        dayOfWeek: 'wednesday',
+      },
+      {
+        type: 'daily',
+        dayOfWeek: 'thursday',
+      },
+      {
+        type: 'daily',
+        dayOfWeek: 'friday',
+      },
+      {
+        type: 'end-of-week',
+      },
+      {
+        type: 'end-of-month',
+      },
+    ])
+  })
+
+  test('when the daily reminder is enabled but it is right before the start time', async () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 13, 8, 59, 0))
+
+    const timeSheet: TimeSheet = {
+      dates,
+      timeCards: [],
+    }
+
+    const extensionOptions: ExtensionOptions = {
+      ...defaultExtensionOptions,
+      dailyTimeEntryReminder: true,
+      dailyReminderStartTime: {
+        hour: 9,
+        minute: 0,
+      },
+    }
+
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
+
+    const actual = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
+
+    expect(actual).toEqual([])
+  })
+
+  test('end of month all submitted or approved', async () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 4, 31, 9, 0, 0))
+
+    const timeSheet: TimeSheet = {
+      dates: endOfMonthDates,
+      timeCards: [
+        {
+          status: 'submitted',
+          hours: {
+            monday: 8,
+            tuesday: 8,
+            wednesday: 8,
+            thursday: 0,
+            friday: 0,
+            saturday: 0,
+            sunday: 0,
+          },
+        },
+      ],
+    }
+
+    const extensionOptions: ExtensionOptions = {
+      ...defaultExtensionOptions,
+      endOfMonthTimesheetReminder: true,
+    }
+
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
+
+    const actual = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
+
+    expect(actual).toEqual([])
+  })
+
+  test('end of month not yet past start time', async () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 4, 31, 8, 59, 0))
+
+    const timeSheet: TimeSheet = {
+      dates: endOfMonthDates,
+      timeCards: [],
+    }
+
+    const extensionOptions: ExtensionOptions = {
+      ...defaultExtensionOptions,
+      endOfMonthTimesheetReminder: true,
+      endOfMonthReminderStartTime: {
+        hour: 9,
+        minute: 0,
+      },
+      dailyTimeEntryReminder: false,
+    }
+
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
+
+    const actual = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
+
+    expect(actual).toEqual([])
+  })
+})
+
+const mockStorage = createMockLocalStorage()
+installMockLocalStorage(mockStorage)
+
+describe('checkShouldNotify', () => {
+  test('returns true when any week since installation date has notifications', async () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 4, 11, 17, 0, 0))
+
+    const installationDate: DateOnly = {
+      year: 2023,
+      month: 5,
+      day: 1,
+    }
+
+    const installWeekSheet: TimeSheet = {
       dates: {
         monday: {
           year: 2023,
           month: 5,
-          day: 29,
+          day: 1,
         },
         tuesday: {
           year: 2023,
           month: 5,
-          day: 30,
+          day: 2,
         },
         wednesday: {
           year: 2023,
           month: 5,
-          day: 31,
+          day: 3,
         },
         thursday: {
           year: 2023,
-          month: 6,
-          day: 1,
+          month: 5,
+          day: 4,
         },
         friday: {
           year: 2023,
-          month: 6,
-          day: 2,
+          month: 5,
+          day: 5,
         },
         saturday: {
           year: 2023,
-          month: 6,
-          day: 3,
+          month: 5,
+          day: 6,
         },
         sunday: {
           year: 2023,
-          month: 6,
-          day: 4,
+          month: 5,
+          day: 7,
         },
       },
       timeCards: [],
+    }
+
+    const currentWeekSheet: TimeSheet = {
+      dates: {
+        monday: {
+          year: 2023,
+          month: 5,
+          day: 8,
+        },
+        tuesday: {
+          year: 2023,
+          month: 5,
+          day: 9,
+        },
+        wednesday: {
+          year: 2023,
+          month: 5,
+          day: 10,
+        },
+        thursday: {
+          year: 2023,
+          month: 5,
+          day: 11,
+        },
+        friday: {
+          year: 2023,
+          month: 5,
+          day: 12,
+        },
+        saturday: {
+          year: 2023,
+          month: 5,
+          day: 13,
+        },
+        sunday: {
+          year: 2023,
+          month: 5,
+          day: 14,
+        },
+      },
+      timeCards: [
+        {
+          status: 'submitted',
+          hours: {
+            monday: 8,
+            tuesday: 8,
+            wednesday: 8,
+            thursday: 8,
+            friday: 8,
+            saturday: 0,
+            sunday: 0,
+          },
+        },
+      ],
+    }
+
+    await mockStorage.set({
+      installationDate,
+      'timesheet-05/01/2023': installWeekSheet,
+      'timesheet-05/08/2023': currentWeekSheet,
     })
 
-    jest.useFakeTimers().setSystemTime(new Date(2023, 5, 31, 0, 0, 0))
+    const actual = await checkShouldNotify(defaultExtensionOptions)
+    expect(actual).toBe(true)
+  })
 
-    const actual = await getActiveNotificationTypes()
-    expect(actual).toEqual(['daily', 'weekly', 'monthly'])
+  test('returns false when all week since installation date have no notifications', async () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 4, 11, 17, 0, 0))
+
+    const installationDate: DateOnly = {
+      year: 2023,
+      month: 5,
+      day: 1,
+    }
+
+    const installWeekSheet: TimeSheet = {
+      dates: {
+        monday: {
+          year: 2023,
+          month: 5,
+          day: 1,
+        },
+        tuesday: {
+          year: 2023,
+          month: 5,
+          day: 2,
+        },
+        wednesday: {
+          year: 2023,
+          month: 5,
+          day: 3,
+        },
+        thursday: {
+          year: 2023,
+          month: 5,
+          day: 4,
+        },
+        friday: {
+          year: 2023,
+          month: 5,
+          day: 5,
+        },
+        saturday: {
+          year: 2023,
+          month: 5,
+          day: 6,
+        },
+        sunday: {
+          year: 2023,
+          month: 5,
+          day: 7,
+        },
+      },
+      timeCards: [
+        {
+          status: 'submitted',
+          hours: {
+            monday: 8,
+            tuesday: 8,
+            wednesday: 8,
+            thursday: 8,
+            friday: 8,
+            saturday: 0,
+            sunday: 0,
+          },
+        },
+      ],
+    }
+
+    const currentWeekSheet: TimeSheet = {
+      dates: {
+        monday: {
+          year: 2023,
+          month: 5,
+          day: 8,
+        },
+        tuesday: {
+          year: 2023,
+          month: 5,
+          day: 9,
+        },
+        wednesday: {
+          year: 2023,
+          month: 5,
+          day: 10,
+        },
+        thursday: {
+          year: 2023,
+          month: 5,
+          day: 11,
+        },
+        friday: {
+          year: 2023,
+          month: 5,
+          day: 12,
+        },
+        saturday: {
+          year: 2023,
+          month: 5,
+          day: 13,
+        },
+        sunday: {
+          year: 2023,
+          month: 5,
+          day: 14,
+        },
+      },
+      timeCards: [
+        {
+          status: 'submitted',
+          hours: {
+            monday: 8,
+            tuesday: 8,
+            wednesday: 8,
+            thursday: 8,
+            friday: 8,
+            saturday: 0,
+            sunday: 0,
+          },
+        },
+      ],
+    }
+
+    await mockStorage.set({
+      installationDate,
+      'timesheet-05/01/2023': installWeekSheet,
+      'timesheet-05/08/2023': currentWeekSheet,
+    })
+
+    const actual = await checkShouldNotify(defaultExtensionOptions)
+    expect(actual).toBe(false)
   })
 })

--- a/extension/__tests__/time-sheets/storage.ts
+++ b/extension/__tests__/time-sheets/storage.ts
@@ -1,0 +1,107 @@
+import { describe, expect, jest, test } from '@jest/globals'
+import { getTimeSheet } from '../../src/time-sheets/storage'
+import { TimeSheet } from '../../src/types/time-sheet'
+
+type GetFunction = (keys?: string | string[] | { [key: string]: any } | null) => Promise<{ [key: string]: any }>
+const getMock = jest.fn<GetFunction>()
+
+const chromeMock = {
+  storage: {
+    local: {
+      get: getMock,
+    },
+  },
+}
+
+const a = globalThis as any
+a.chrome = chromeMock
+
+const expectedDefaultTimeSheet: TimeSheet = {
+  dates: {
+    monday: { year: 2021, month: 1, day: 4 },
+    tuesday: { year: 2021, month: 1, day: 5 },
+    wednesday: { year: 2021, month: 1, day: 6 },
+    thursday: { year: 2021, month: 1, day: 7 },
+    friday: { year: 2021, month: 1, day: 8 },
+    saturday: { year: 2021, month: 1, day: 9 },
+    sunday: { year: 2021, month: 1, day: 10 },
+  },
+  timeCards: [],
+}
+
+describe('getExtensionOptions', () => {
+  test('returns expected default when nothing is in storage', async () => {
+    getMock.mockResolvedValue({})
+
+    const actual = await getTimeSheet({ year: 2021, month: 1, day: 4 })
+    expect(actual).toEqual(expectedDefaultTimeSheet)
+  })
+
+  test('returns defaults when an incompatible version is in storage', async () => {
+    getMock.mockResolvedValue({
+      'timesheet-01/04/2021': {
+        dates: true,
+      },
+    })
+
+    const actual = await getTimeSheet({ year: 2021, month: 1, day: 4 })
+    expect(actual).toEqual(expectedDefaultTimeSheet)
+  })
+
+  test('returns time sheet when in storage', async () => {
+    getMock.mockResolvedValue({
+      'timesheet-01/04/2021': {
+        dates: {
+          monday: { year: 2021, month: 1, day: 4 },
+          tuesday: { year: 2021, month: 1, day: 5 },
+          wednesday: { year: 2021, month: 1, day: 6 },
+          thursday: { year: 2021, month: 1, day: 7 },
+          friday: { year: 2021, month: 1, day: 8 },
+          saturday: { year: 2021, month: 1, day: 9 },
+          sunday: { year: 2021, month: 1, day: 10 },
+        },
+        timeCards: [
+          {
+            hours: {
+              monday: 8,
+              tuesday: 7,
+              wednesday: 6,
+              thursday: 5,
+              friday: 4,
+              saturday: 3,
+              sunday: 2,
+            },
+            status: 'approved',
+          },
+        ],
+      },
+    })
+
+    const actual = await getTimeSheet({ year: 2021, month: 1, day: 4 })
+    expect(actual).toEqual({
+      dates: {
+        monday: { year: 2021, month: 1, day: 4 },
+        tuesday: { year: 2021, month: 1, day: 5 },
+        wednesday: { year: 2021, month: 1, day: 6 },
+        thursday: { year: 2021, month: 1, day: 7 },
+        friday: { year: 2021, month: 1, day: 8 },
+        saturday: { year: 2021, month: 1, day: 9 },
+        sunday: { year: 2021, month: 1, day: 10 },
+      },
+      timeCards: [
+        {
+          hours: {
+            monday: 8,
+            tuesday: 7,
+            wednesday: 6,
+            thursday: 5,
+            friday: 4,
+            saturday: 3,
+            sunday: 2,
+          },
+          status: 'approved',
+        },
+      ],
+    })
+  })
+})

--- a/extension/__tests__/time-sheets/summary.ts
+++ b/extension/__tests__/time-sheets/summary.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, jest, test } from '@jest/globals'
 import { summarizeTimeSheet } from '../../src/time-sheets/summary'
+import { ExtensionOptions } from '../../src/types/extension-options'
 import { TimeSheet, TimeSheetDates, TimeSheetSummary } from '../../src/types/time-sheet'
 
 const dates: TimeSheetDates = {
@@ -40,7 +41,7 @@ const dates: TimeSheetDates = {
   },
 }
 
-const endOfWeekDates: TimeSheetDates = {
+const endOfMonthDates: TimeSheetDates = {
   monday: {
     year: 2023,
     month: 5,
@@ -78,6 +79,36 @@ const endOfWeekDates: TimeSheetDates = {
   },
 }
 
+const defaultExtensionOptions: ExtensionOptions = {
+  dailyTimeEntryReminder: true,
+  endOfMonthTimesheetReminder: true,
+  endOfWeekTimesheetReminder: true,
+  gifDataUrl: 'gifs/clockstorm.gif',
+  soundDataUrl: 'sounds/cricket.wav',
+  dailyReminderDaysOfWeek: ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'],
+  dailyReminderStartTime: {
+    hour: 9,
+    minute: 0,
+  },
+  endOfWeekReminderDayOfWeek: 'thursday',
+  endOfWeekReminderStartTime: {
+    hour: 9,
+    minute: 0,
+  },
+  endOfWeekReminderDueTime: {
+    hour: 17,
+    minute: 0,
+  },
+  endOfMonthReminderStartTime: {
+    hour: 9,
+    minute: 0,
+  },
+  endOfMonthReminderDueTime: {
+    hour: 17,
+    minute: 0,
+  },
+}
+
 describe('summarizeTimeSheet', () => {
   beforeAll(() => {
     jest.useFakeTimers().setSystemTime(new Date(2023, 2, 19, 0, 0, 0))
@@ -103,10 +134,10 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '00:00:00',
       weekStatus: 'no-time-cards',
-      alertableLastDayOfMonth: null,
+      endOfMonthReminderDate: null,
     }
 
-    expect(summarizeTimeSheet(emptyTimeSheet)).toEqual(expected)
+    expect(summarizeTimeSheet(emptyTimeSheet, defaultExtensionOptions)).toEqual(expected)
   })
 
   test('when all days are filled out but not submitted', () => {
@@ -142,10 +173,10 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '00:00:00',
       weekStatus: 'some-unsubmitted',
-      alertableLastDayOfMonth: null,
+      endOfMonthReminderDate: null,
     }
 
-    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+    expect(summarizeTimeSheet(timeSheet, defaultExtensionOptions)).toEqual(expected)
   })
 
   test('when there are two time cards and both are submitted', () => {
@@ -193,10 +224,10 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 5,
       timeRemaining: '00:00:00',
       weekStatus: 'all-submitted-or-approved',
-      alertableLastDayOfMonth: null,
+      endOfMonthReminderDate: null,
     }
 
-    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+    expect(summarizeTimeSheet(timeSheet, defaultExtensionOptions)).toEqual(expected)
   })
 
   test('when there are two time cards and one is submitted', () => {
@@ -244,10 +275,10 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 2,
       timeRemaining: '00:00:00',
       weekStatus: 'some-unsubmitted',
-      alertableLastDayOfMonth: null,
+      endOfMonthReminderDate: null,
     }
 
-    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+    expect(summarizeTimeSheet(timeSheet, defaultExtensionOptions)).toEqual(expected)
   })
 
   test('when there are two time cards and one includes the weekend', () => {
@@ -295,10 +326,10 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 2,
       timeRemaining: '00:00:00',
       weekStatus: 'some-unsubmitted',
-      alertableLastDayOfMonth: null,
+      endOfMonthReminderDate: null,
     }
 
-    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+    expect(summarizeTimeSheet(timeSheet, defaultExtensionOptions)).toEqual(expected)
   })
 
   test('when you have a time card that is not saved', () => {
@@ -334,10 +365,10 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '00:00:00',
       weekStatus: 'some-unsaved',
-      alertableLastDayOfMonth: null,
+      endOfMonthReminderDate: null,
     }
 
-    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+    expect(summarizeTimeSheet(timeSheet, defaultExtensionOptions)).toEqual(expected)
   })
 
   test('when you have 25 hours left', () => {
@@ -375,10 +406,10 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '25:00:00',
       weekStatus: 'some-unsaved',
-      alertableLastDayOfMonth: null,
+      endOfMonthReminderDate: null,
     }
 
-    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+    expect(summarizeTimeSheet(timeSheet, defaultExtensionOptions)).toEqual(expected)
   })
 
   test('when you have 1 second left', () => {
@@ -416,10 +447,10 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '00:00:01',
       weekStatus: 'some-unsaved',
-      alertableLastDayOfMonth: null,
+      endOfMonthReminderDate: null,
     }
 
-    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+    expect(summarizeTimeSheet(timeSheet, defaultExtensionOptions)).toEqual(expected)
   })
 
   test('when you have no time left', () => {
@@ -457,10 +488,10 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '00:00:00',
       weekStatus: 'some-unsaved',
-      alertableLastDayOfMonth: null,
+      endOfMonthReminderDate: null,
     }
 
-    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+    expect(summarizeTimeSheet(timeSheet, defaultExtensionOptions)).toEqual(expected)
   })
 
   test('when your time card is approved', () => {
@@ -496,17 +527,17 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 5,
       timeRemaining: '00:00:00',
       weekStatus: 'all-submitted-or-approved',
-      alertableLastDayOfMonth: null,
+      endOfMonthReminderDate: null,
     }
 
-    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+    expect(summarizeTimeSheet(timeSheet, defaultExtensionOptions)).toEqual(expected)
   })
 
-  test('when the end of the week is wednesday', () => {
+  test('when the end of the month is wednesday', () => {
     jest.useFakeTimers().setSystemTime(new Date(2023, 4, 31, 0, 0, 0))
 
     const timeSheet: TimeSheet = {
-      dates: endOfWeekDates,
+      dates: endOfMonthDates,
       timeCards: [],
     }
 
@@ -524,17 +555,21 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '17:00:00',
       weekStatus: 'no-time-cards',
-      alertableLastDayOfMonth: 'wednesday',
+      endOfMonthReminderDate: {
+        day: 31,
+        month: 5,
+        year: 2023,
+      },
     }
 
-    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+    expect(summarizeTimeSheet(timeSheet, defaultExtensionOptions)).toEqual(expected)
   })
 
-  test('when the end of the week is wednesday + buzzer beater', () => {
+  test('when the end of the month is wednesday + buzzer beater', () => {
     jest.useFakeTimers().setSystemTime(new Date(2023, 4, 31, 17, 0, 0))
 
     const timeSheet: TimeSheet = {
-      dates: endOfWeekDates,
+      dates: endOfMonthDates,
       timeCards: [],
     }
 
@@ -552,17 +587,21 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '00:00:00',
       weekStatus: 'no-time-cards',
-      alertableLastDayOfMonth: 'wednesday',
+      endOfMonthReminderDate: {
+        day: 31,
+        month: 5,
+        year: 2023,
+      },
     }
 
-    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+    expect(summarizeTimeSheet(timeSheet, defaultExtensionOptions)).toEqual(expected)
   })
 
-  test('when the end of the week is wednesday + buzzer beater failure', () => {
+  test('when the end of the month is wednesday + buzzer beater failure', () => {
     jest.useFakeTimers().setSystemTime(new Date(2023, 4, 31, 17, 0, 1))
 
     const timeSheet: TimeSheet = {
-      dates: endOfWeekDates,
+      dates: endOfMonthDates,
       timeCards: [],
     }
 
@@ -580,9 +619,141 @@ describe('summarizeTimeSheet', () => {
       totalDaysSubmitted: 0,
       timeRemaining: '23:59:59',
       weekStatus: 'no-time-cards',
-      alertableLastDayOfMonth: 'wednesday',
+      endOfMonthReminderDate: {
+        day: 31,
+        month: 5,
+        year: 2023,
+      },
     }
 
-    expect(summarizeTimeSheet(timeSheet)).toEqual(expected)
+    expect(summarizeTimeSheet(timeSheet, defaultExtensionOptions)).toEqual(expected)
+  })
+
+  test('when the end of the month is friday which is after the due date', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 3, 30, 9, 0, 0))
+
+    const timeSheet: TimeSheet = {
+      dates: {
+        monday: {
+          year: 2023,
+          month: 4,
+          day: 27,
+        },
+        tuesday: {
+          year: 2023,
+          month: 4,
+          day: 28,
+        },
+        wednesday: {
+          year: 2023,
+          month: 4,
+          day: 29,
+        },
+        thursday: {
+          year: 2023,
+          month: 4,
+          day: 30,
+        },
+        friday: {
+          year: 2023,
+          month: 4,
+          day: 31,
+        },
+        saturday: {
+          year: 2023,
+          month: 5,
+          day: 1,
+        },
+        sunday: {
+          year: 2023,
+          month: 5,
+          day: 2,
+        },
+      },
+      timeCards: [],
+    }
+
+    const expected: TimeSheetSummary = {
+      daysFilled: {
+        monday: false,
+        tuesday: false,
+        wednesday: false,
+        thursday: false,
+        friday: false,
+        saturday: false,
+        sunday: false,
+      },
+      totalDaysSaved: 0,
+      totalDaysSubmitted: 0,
+      timeRemaining: '08:00:00',
+      weekStatus: 'no-time-cards',
+      endOfMonthReminderDate: null,
+    }
+
+    expect(summarizeTimeSheet(timeSheet, defaultExtensionOptions)).toEqual(expected)
+  })
+
+  test('when the end of the month is thursday which is on the due date', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 7, 31, 9, 0, 0))
+
+    const timeSheet: TimeSheet = {
+      dates: {
+        monday: {
+          year: 2023,
+          month: 8,
+          day: 28,
+        },
+        tuesday: {
+          year: 2023,
+          month: 8,
+          day: 29,
+        },
+        wednesday: {
+          year: 2023,
+          month: 8,
+          day: 30,
+        },
+        thursday: {
+          year: 2023,
+          month: 8,
+          day: 31,
+        },
+        friday: {
+          year: 2023,
+          month: 9,
+          day: 1,
+        },
+        saturday: {
+          year: 2023,
+          month: 9,
+          day: 2,
+        },
+        sunday: {
+          year: 2023,
+          month: 9,
+          day: 3,
+        },
+      },
+      timeCards: [],
+    }
+
+    const expected: TimeSheetSummary = {
+      daysFilled: {
+        monday: false,
+        tuesday: false,
+        wednesday: false,
+        thursday: false,
+        friday: false,
+        saturday: false,
+        sunday: false,
+      },
+      totalDaysSaved: 0,
+      totalDaysSubmitted: 0,
+      timeRemaining: '08:00:00',
+      weekStatus: 'no-time-cards',
+      endOfMonthReminderDate: null,
+    }
+
+    expect(summarizeTimeSheet(timeSheet, defaultExtensionOptions)).toEqual(expected)
   })
 })

--- a/extension/__tests__/types/dates.ts
+++ b/extension/__tests__/types/dates.ts
@@ -1,0 +1,380 @@
+import { beforeAll, describe, expect, jest, test } from '@jest/globals'
+import {
+  addDays,
+  addMinutes,
+  compareDateOnly,
+  compareTimeOnly,
+  convertInputTimeToTimeOnly,
+  convertTimeOnlyToInputTime,
+  fromDateOnlyKey,
+  getDayOfWeek,
+  getDisplayDayOfWeek,
+  getLastDayOfMonth,
+  getMondayOfDateOnly,
+  getTimeOnly,
+  getTodayDateOnly,
+  isTimeWithinRange,
+  isValidTimeOnlyInput,
+  minusDays,
+  minusMinutes,
+  toDateOnlyKey,
+} from '../../src/types/dates'
+
+describe('toDateOnlyKey', () => {
+  test('returns the correct padded string', () => {
+    expect(toDateOnlyKey({ year: 2021, month: 1, day: 2 })).toBe('01/02/2021')
+  })
+
+  test('returns the correct unpadded string', () => {
+    expect(toDateOnlyKey({ year: 2022, month: 12, day: 31 })).toBe('12/31/2022')
+  })
+})
+
+describe('getDisplayDayOfWeek', () => {
+  test('returns the correct display value', () => {
+    expect(getDisplayDayOfWeek('monday')).toBe('Monday')
+    expect(getDisplayDayOfWeek('tuesday')).toBe('Tuesday')
+    expect(getDisplayDayOfWeek('wednesday')).toBe('Wednesday')
+    expect(getDisplayDayOfWeek('thursday')).toBe('Thursday')
+    expect(getDisplayDayOfWeek('friday')).toBe('Friday')
+    expect(getDisplayDayOfWeek('saturday')).toBe('Saturday')
+    expect(getDisplayDayOfWeek('sunday')).toBe('Sunday')
+  })
+})
+
+describe('fromDateOnlyKey', () => {
+  test('returns the correct date', () => {
+    expect(fromDateOnlyKey('01/02/2021')).toEqual({ year: 2021, month: 1, day: 2 })
+  })
+
+  test('throws an error when the date is invalid', () => {
+    expect(() => {
+      fromDateOnlyKey('01/02')
+    }).toThrow()
+  })
+})
+
+describe('addDays', () => {
+  test('wraps to the next month', () => {
+    expect(addDays({ year: 2021, month: 1, day: 31 }, 1)).toEqual({ year: 2021, month: 2, day: 1 })
+  })
+
+  test('wraps to the next year', () => {
+    expect(addDays({ year: 2021, month: 12, day: 31 }, 1)).toEqual({ year: 2022, month: 1, day: 1 })
+  })
+
+  test('adds days correctly', () => {
+    expect(addDays({ year: 2021, month: 1, day: 1 }, 5)).toEqual({ year: 2021, month: 1, day: 6 })
+  })
+})
+
+describe('minusDays', () => {
+  test('wraps to the previous month', () => {
+    expect(minusDays({ year: 2021, month: 2, day: 1 }, 1)).toEqual({ year: 2021, month: 1, day: 31 })
+  })
+
+  test('wraps to the previous year', () => {
+    expect(minusDays({ year: 2022, month: 1, day: 1 }, 1)).toEqual({ year: 2021, month: 12, day: 31 })
+  })
+
+  test('subtracts days correctly', () => {
+    expect(minusDays({ year: 2021, month: 1, day: 6 }, 5)).toEqual({ year: 2021, month: 1, day: 1 })
+  })
+})
+
+describe('minusMinutes', () => {
+  test('returns null when the time is before 00:00', () => {
+    expect(minusMinutes({ hour: 0, minute: 0 }, 1)).toBeNull()
+  })
+
+  test('returns the correct time', () => {
+    expect(minusMinutes({ hour: 1, minute: 1 }, 1)).toEqual({ hour: 1, minute: 0 })
+  })
+
+  test('wraps to the previous hour', () => {
+    expect(minusMinutes({ hour: 1, minute: 0 }, 1)).toEqual({ hour: 0, minute: 59 })
+  })
+
+  test('wraps to the second previous hour', () => {
+    expect(minusMinutes({ hour: 2, minute: 0 }, 61)).toEqual({ hour: 0, minute: 59 })
+  })
+})
+
+describe('addMinutes', () => {
+  test('returns null when the time is after 23:59', () => {
+    expect(addMinutes({ hour: 23, minute: 59 }, 1)).toBeNull()
+  })
+
+  test('returns the correct time', () => {
+    expect(addMinutes({ hour: 1, minute: 0 }, 1)).toEqual({ hour: 1, minute: 1 })
+  })
+
+  test('wraps to the next hour', () => {
+    expect(addMinutes({ hour: 1, minute: 59 }, 1)).toEqual({ hour: 2, minute: 0 })
+  })
+
+  test('wraps to the second next hour', () => {
+    expect(addMinutes({ hour: 0, minute: 59 }, 61)).toEqual({ hour: 2, minute: 0 })
+  })
+})
+
+describe('compareTimeOnly', () => {
+  test('returns 0 when the times are equal', () => {
+    expect(compareTimeOnly({ hour: 1, minute: 0 }, { hour: 1, minute: 0 })).toBe(0)
+  })
+
+  test('returns -1 when the first time is before the second time (same hour)', () => {
+    expect(compareTimeOnly({ hour: 1, minute: 0 }, { hour: 1, minute: 1 })).toBe(-1)
+  })
+
+  test('returns -1 when the first time is before the second time (different hours)', () => {
+    expect(compareTimeOnly({ hour: 0, minute: 0 }, { hour: 1, minute: 0 })).toBe(-1)
+  })
+
+  test('returns 1 when the first time is after the second time (same hour)', () => {
+    expect(compareTimeOnly({ hour: 1, minute: 1 }, { hour: 1, minute: 0 })).toBe(1)
+  })
+
+  test('returns 1 when the first time is after the second time (different hours)', () => {
+    expect(compareTimeOnly({ hour: 1, minute: 0 }, { hour: 0, minute: 0 })).toBe(1)
+  })
+})
+
+describe('compareDateOnly', () => {
+  test('returns 0 when the dates are equal', () => {
+    expect(compareDateOnly({ year: 2021, month: 1, day: 1 }, { year: 2021, month: 1, day: 1 })).toBe(0)
+  })
+
+  test('returns -1 when the first date is before the second date (same year and month)', () => {
+    expect(compareDateOnly({ year: 2021, month: 1, day: 1 }, { year: 2021, month: 1, day: 2 })).toBe(-1)
+  })
+
+  test('returns 1 when the first date is after the second date (same year and month)', () => {
+    expect(compareDateOnly({ year: 2021, month: 1, day: 2 }, { year: 2021, month: 1, day: 1 })).toBe(1)
+  })
+
+  test('returns -1 when the first date is before the second date (same year)', () => {
+    expect(compareDateOnly({ year: 2021, month: 1, day: 1 }, { year: 2021, month: 2, day: 1 })).toBe(-1)
+  })
+
+  test('returns 1 when the first date is after the second date (same year)', () => {
+    expect(compareDateOnly({ year: 2021, month: 2, day: 1 }, { year: 2021, month: 1, day: 1 })).toBe(1)
+  })
+
+  test('returns -1 when the first date is before the second date (different years)', () => {
+    expect(compareDateOnly({ year: 2021, month: 1, day: 1 }, { year: 2022, month: 1, day: 1 })).toBe(-1)
+  })
+
+  test('returns 1 when the first date is after the second date (different years)', () => {
+    expect(compareDateOnly({ year: 2022, month: 1, day: 1 }, { year: 2021, month: 1, day: 1 })).toBe(1)
+  })
+})
+
+describe('isTimeWithinRange', () => {
+  test('returns true when all the times are the same', () => {
+    expect(isTimeWithinRange({ hour: 1, minute: 0 }, { hour: 1, minute: 0 }, { hour: 1, minute: 0 })).toBe(true)
+  })
+
+  test('returns true when the time is within the range', () => {
+    expect(isTimeWithinRange({ hour: 1, minute: 0 }, { hour: 0, minute: 0 }, { hour: 2, minute: 0 })).toBe(true)
+  })
+
+  test('returns true when the time is equal to the start of the range', () => {
+    expect(isTimeWithinRange({ hour: 0, minute: 0 }, { hour: 0, minute: 0 }, { hour: 2, minute: 0 })).toBe(true)
+  })
+
+  test('returns true when the time is equal to the end of the range', () => {
+    expect(isTimeWithinRange({ hour: 2, minute: 0 }, { hour: 0, minute: 0 }, { hour: 2, minute: 0 })).toBe(true)
+  })
+
+  test('returns false when the time is before the start of the range', () => {
+    expect(isTimeWithinRange({ hour: 0, minute: 0 }, { hour: 1, minute: 0 }, { hour: 2, minute: 0 })).toBe(false)
+  })
+
+  test('returns false when the time is after the end of the range', () => {
+    expect(isTimeWithinRange({ hour: 3, minute: 0 }, { hour: 1, minute: 0 }, { hour: 2, minute: 0 })).toBe(false)
+  })
+})
+
+describe('getTodayDateOnly', () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 19, 0, 0, 0))
+  })
+
+  test('returns the correct date', () => {
+    expect(getTodayDateOnly()).toEqual({ year: 2023, month: 3, day: 19 })
+  })
+})
+
+describe('getTimeOnly', () => {
+  test('returns the correct time', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 19, 1, 23, 0))
+    expect(getTimeOnly()).toEqual({ hour: 1, minute: 23 })
+  })
+
+  test('midnight', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 19, 0, 0, 0))
+    expect(getTimeOnly()).toEqual({ hour: 0, minute: 0 })
+  })
+
+  test('noon', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 19, 12, 0, 0))
+    expect(getTimeOnly()).toEqual({ hour: 12, minute: 0 })
+  })
+
+  test('almost midnight', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2023, 2, 19, 23, 59, 0))
+    expect(getTimeOnly()).toEqual({ hour: 23, minute: 59 })
+  })
+})
+
+describe('getDayOfWeek', () => {
+  test('returns the correct day of the week (monday)', () => {
+    expect(getDayOfWeek({ year: 2023, month: 3, day: 20 })).toBe('monday')
+  })
+
+  test('returns the correct day of the week (tuesday)', () => {
+    expect(getDayOfWeek({ year: 2023, month: 3, day: 21 })).toBe('tuesday')
+  })
+
+  test('returns the correct day of the week (wednesday)', () => {
+    expect(getDayOfWeek({ year: 2023, month: 3, day: 22 })).toBe('wednesday')
+  })
+
+  test('returns the correct day of the week (thursday)', () => {
+    expect(getDayOfWeek({ year: 2023, month: 3, day: 23 })).toBe('thursday')
+  })
+
+  test('returns the correct day of the week (friday)', () => {
+    expect(getDayOfWeek({ year: 2023, month: 3, day: 24 })).toBe('friday')
+  })
+
+  test('returns the correct day of the week (saturday)', () => {
+    expect(getDayOfWeek({ year: 2023, month: 3, day: 25 })).toBe('saturday')
+  })
+
+  test('returns the correct day of the week (sunday)', () => {
+    expect(getDayOfWeek({ year: 2023, month: 3, day: 26 })).toBe('sunday')
+  })
+})
+
+describe('getMondayOfDateOnly', () => {
+  test('returns the same day if the input is a monday', () => {
+    expect(getMondayOfDateOnly({ year: 2023, month: 3, day: 20 })).toEqual({ year: 2023, month: 3, day: 20 })
+  })
+
+  test('returns the day prior if the input is a tuesday', () => {
+    expect(getMondayOfDateOnly({ year: 2023, month: 3, day: 21 })).toEqual({ year: 2023, month: 3, day: 20 })
+  })
+
+  test('returns two days prior if the input is a wednesday', () => {
+    expect(getMondayOfDateOnly({ year: 2023, month: 3, day: 22 })).toEqual({ year: 2023, month: 3, day: 20 })
+  })
+
+  test('returns three days prior if the input is a thursday', () => {
+    expect(getMondayOfDateOnly({ year: 2023, month: 3, day: 23 })).toEqual({ year: 2023, month: 3, day: 20 })
+  })
+
+  test('returns four days prior if the input is a friday', () => {
+    expect(getMondayOfDateOnly({ year: 2023, month: 3, day: 24 })).toEqual({ year: 2023, month: 3, day: 20 })
+  })
+
+  test('returns five days prior if the input is a saturday', () => {
+    expect(getMondayOfDateOnly({ year: 2023, month: 3, day: 25 })).toEqual({ year: 2023, month: 3, day: 20 })
+  })
+
+  test('returns six days prior if the input is a sunday', () => {
+    expect(getMondayOfDateOnly({ year: 2023, month: 3, day: 26 })).toEqual({ year: 2023, month: 3, day: 20 })
+  })
+})
+
+describe('getLastDayOfMonth', () => {
+  test('returns the last day of the month (may 2023)', () => {
+    expect(getLastDayOfMonth(5, 2023)).toEqual(31)
+  })
+
+  test('returns the last day of the month (june 2023)', () => {
+    expect(getLastDayOfMonth(6, 2023)).toEqual(30)
+  })
+
+  test('returns the last day of the month (february 2024 leap year)', () => {
+    expect(getLastDayOfMonth(2, 2024)).toEqual(29)
+  })
+
+  test('returns the last day of the month (february 2023 not leap year)', () => {
+    expect(getLastDayOfMonth(2, 2023)).toEqual(28)
+  })
+})
+
+describe('isValidTimeOnlyInput', () => {
+  test('returns true if the input is valid', () => {
+    expect(isValidTimeOnlyInput('12:00')).toBe(true)
+    expect(isValidTimeOnlyInput('00:00')).toBe(true)
+    expect(isValidTimeOnlyInput('23:59')).toBe(true)
+    expect(isValidTimeOnlyInput('00:01')).toBe(true)
+    expect(isValidTimeOnlyInput('01:00')).toBe(true)
+    expect(isValidTimeOnlyInput('01:01')).toBe(true)
+  })
+
+  test('returns false if the input is invalid', () => {
+    expect(isValidTimeOnlyInput('')).toBe(false)
+    expect(isValidTimeOnlyInput('12:')).toBe(false)
+    expect(isValidTimeOnlyInput(':00')).toBe(false)
+    expect(isValidTimeOnlyInput('12:0')).toBe(false)
+    expect(isValidTimeOnlyInput('1:00')).toBe(false)
+    expect(isValidTimeOnlyInput('12:000')).toBe(false)
+    expect(isValidTimeOnlyInput('120:00')).toBe(false)
+    expect(isValidTimeOnlyInput('24:00')).toBe(false)
+  })
+})
+
+describe('convertInputTimeToTimeOnly', () => {
+  test('returns the correct time', () => {
+    expect(convertInputTimeToTimeOnly('12:00')).toEqual({
+      hour: 12,
+      minute: 0,
+    })
+    expect(convertInputTimeToTimeOnly('00:00')).toEqual({
+      hour: 0,
+      minute: 0,
+    })
+    expect(convertInputTimeToTimeOnly('23:59')).toEqual({
+      hour: 23,
+      minute: 59,
+    })
+    expect(convertInputTimeToTimeOnly('00:01')).toEqual({
+      hour: 0,
+      minute: 1,
+    })
+    expect(convertInputTimeToTimeOnly('01:00')).toEqual({
+      hour: 1,
+      minute: 0,
+    })
+    expect(convertInputTimeToTimeOnly('01:01')).toEqual({
+      hour: 1,
+      minute: 1,
+    })
+  })
+
+  test('returns null if the input is invalid', () => {
+    expect(convertInputTimeToTimeOnly('')).toBe(null)
+    expect(convertInputTimeToTimeOnly('12:')).toBe(null)
+    expect(convertInputTimeToTimeOnly(':00')).toBe(null)
+    expect(convertInputTimeToTimeOnly('12:0')).toBe(null)
+    expect(convertInputTimeToTimeOnly('1:00')).toBe(null)
+    expect(convertInputTimeToTimeOnly('12:000')).toBe(null)
+    expect(convertInputTimeToTimeOnly('120:00')).toBe(null)
+    expect(convertInputTimeToTimeOnly('24:00')).toBe(null)
+  })
+})
+
+describe('convertTimeOnlyToInputTime', () => {
+  test('returns the correct time', () => {
+    expect(convertTimeOnlyToInputTime({ hour: 12, minute: 0 })).toEqual('12:00')
+    expect(convertTimeOnlyToInputTime({ hour: 0, minute: 0 })).toEqual('00:00')
+    expect(convertTimeOnlyToInputTime({ hour: 23, minute: 59 })).toEqual('23:59')
+    expect(convertTimeOnlyToInputTime({ hour: 0, minute: 1 })).toEqual('00:01')
+    expect(convertTimeOnlyToInputTime({ hour: 1, minute: 0 })).toEqual('01:00')
+    expect(convertTimeOnlyToInputTime({ hour: 1, minute: 1 })).toEqual('01:01')
+  })
+})

--- a/extension/__tests__/types/time-sheet.ts
+++ b/extension/__tests__/types/time-sheet.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from '@jest/globals'
+import { isTimeSheetEqual } from '../../src/types/time-sheet'
+
+describe('isTimeSheetEqual', () => {
+  test('returns true when time sheets are equal', () => {
+    expect(
+      isTimeSheetEqual(
+        {
+          dates: {
+            monday: { year: 2021, month: 1, day: 4 },
+            tuesday: { year: 2021, month: 1, day: 5 },
+            wednesday: { year: 2021, month: 1, day: 6 },
+            thursday: { year: 2021, month: 1, day: 7 },
+            friday: { year: 2021, month: 1, day: 8 },
+            saturday: { year: 2021, month: 1, day: 9 },
+            sunday: { year: 2021, month: 1, day: 10 },
+          },
+          timeCards: [
+            {
+              hours: {
+                monday: 8,
+                tuesday: 7,
+                wednesday: 6,
+                thursday: 5,
+                friday: 4,
+                saturday: 3,
+                sunday: 2,
+              },
+              status: 'approved',
+            },
+          ],
+        },
+        {
+          dates: {
+            monday: { year: 2021, month: 1, day: 4 },
+            tuesday: { year: 2021, month: 1, day: 5 },
+            wednesday: { year: 2021, month: 1, day: 6 },
+            thursday: { year: 2021, month: 1, day: 7 },
+            friday: { year: 2021, month: 1, day: 8 },
+            saturday: { year: 2021, month: 1, day: 9 },
+            sunday: { year: 2021, month: 1, day: 10 },
+          },
+          timeCards: [
+            {
+              hours: {
+                monday: 8,
+                tuesday: 7,
+                wednesday: 6,
+                thursday: 5,
+                friday: 4,
+                saturday: 3,
+                sunday: 2,
+              },
+              status: 'approved',
+            },
+          ],
+        },
+      ),
+    ).toBe(true)
+  })
+
+  test('returns false when time sheets are not equal', () => {
+    expect(
+      isTimeSheetEqual(
+        {
+          dates: {
+            monday: { year: 2021, month: 1, day: 4 },
+            tuesday: { year: 2021, month: 1, day: 5 },
+            wednesday: { year: 2021, month: 1, day: 6 },
+            thursday: { year: 2021, month: 1, day: 7 },
+            friday: { year: 2021, month: 1, day: 8 },
+            saturday: { year: 2021, month: 1, day: 9 },
+            sunday: { year: 2021, month: 1, day: 10 },
+          },
+          timeCards: [
+            {
+              hours: {
+                monday: 8,
+                tuesday: 7,
+                wednesday: 6,
+                thursday: 5,
+                friday: 4,
+                saturday: 3,
+                sunday: 2,
+              },
+              status: 'approved',
+            },
+          ],
+        },
+        {
+          dates: {
+            monday: { year: 2021, month: 1, day: 4 },
+            tuesday: { year: 2021, month: 1, day: 5 },
+            wednesday: { year: 2021, month: 1, day: 6 },
+            thursday: { year: 2021, month: 1, day: 7 },
+            friday: { year: 2021, month: 1, day: 8 },
+            saturday: { year: 2021, month: 1, day: 9 },
+            sunday: { year: 2021, month: 1, day: 10 },
+          },
+          timeCards: [
+            {
+              hours: {
+                monday: 8,
+                tuesday: 7,
+                wednesday: 6,
+                thursday: 5,
+                friday: 3,
+                saturday: 3,
+                sunday: 2,
+              },
+              status: 'approved',
+            },
+          ],
+        },
+      ),
+    ).toBe(false)
+  })
+})

--- a/extension/jest.config.ts
+++ b/extension/jest.config.ts
@@ -10,4 +10,5 @@ export default {
   coverageProvider: 'v8',
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',
+  testPathIgnorePatterns: ['/mocks/', '/node_modules/'],
 }

--- a/extension/src/extension-options/daily-reminder.ts
+++ b/extension/src/extension-options/daily-reminder.ts
@@ -1,0 +1,49 @@
+import { convertInputTimeToTimeOnly, convertTimeOnlyToInputTime, DayOfWeek, TimeOnly } from '@src/types/dates'
+import { ExtensionOptions } from '@src/types/extension-options'
+import { validator } from './validator'
+
+const validate = () => {
+  const dailyReminderError = document.getElementById('daily-reminder-error') as HTMLDivElement
+
+  const validDays = document.getElementById('daily-reminder-days').querySelectorAll('button.selected').length > 0
+  validator.setValid('daily-reminder-days', validDays)
+
+  if (validDays) {
+    dailyReminderError.classList.add('hidden')
+  } else {
+    dailyReminderError.classList.remove('hidden')
+  }
+}
+
+export const createDailyReminderSelectors = (extensionOptions: ExtensionOptions) => {
+  const daysElement = document.getElementById('daily-reminder-days') as HTMLDivElement
+  const dayButtons = daysElement.querySelectorAll('button') as NodeListOf<HTMLButtonElement>
+  const startTimeElement = document.getElementById('daily-reminder-start-time') as HTMLInputElement
+
+  dayButtons.forEach((button) => {
+    const buttonDayOfWeek = button.getAttribute('data-day-of-week') as DayOfWeek
+
+    if (extensionOptions.dailyReminderDaysOfWeek.includes(buttonDayOfWeek)) {
+      button.classList.add('selected')
+    }
+
+    button.addEventListener('click', (e) => {
+      e.preventDefault()
+      button.classList.toggle('selected')
+      validate()
+    })
+  })
+
+  startTimeElement.value = convertTimeOnlyToInputTime(extensionOptions.dailyReminderStartTime)
+}
+
+export const getDailyReminderSelectedDays = (): DayOfWeek[] => {
+  const daysElement = document.getElementById('daily-reminder-days') as HTMLDivElement
+  const buttons = daysElement.querySelectorAll('button.selected') as NodeListOf<HTMLButtonElement>
+  return Array.from(buttons).map((button) => button.getAttribute('data-day-of-week') as DayOfWeek)
+}
+
+export const getDailyReminderSelectedStartTime = (): TimeOnly => {
+  const timeElement = document.getElementById('daily-reminder-start-time') as HTMLInputElement
+  return convertInputTimeToTimeOnly(timeElement.value)
+}

--- a/extension/src/extension-options/end-of-month-reminder.ts
+++ b/extension/src/extension-options/end-of-month-reminder.ts
@@ -1,0 +1,55 @@
+import { compareTimeOnly, convertInputTimeToTimeOnly, convertTimeOnlyToInputTime, TimeOnly } from '@src/types/dates'
+import { ExtensionOptions } from '@src/types/extension-options'
+import { validator } from './validator'
+
+export const isValidTimes = (): boolean => {
+  const startTimeElement = document.getElementById('end-of-month-start-time') as HTMLInputElement
+  const dueTimeElement = document.getElementById('end-of-month-due-time') as HTMLInputElement
+
+  const startTime = convertInputTimeToTimeOnly(startTimeElement.value)
+  const dueTime = convertInputTimeToTimeOnly(dueTimeElement.value)
+
+  if (!startTime || !dueTime) {
+    return false
+  }
+
+  if (compareTimeOnly(dueTime, startTime) <= 0) {
+    return false
+  }
+
+  return true
+}
+
+const validate = () => {
+  const errorElement = document.getElementById('end-of-month-error') as HTMLDivElement
+
+  const validTimes = isValidTimes()
+  validator.setValid('end-of-month-reminder-times', isValidTimes())
+
+  if (validTimes) {
+    errorElement.classList.add('hidden')
+  } else {
+    errorElement.classList.remove('hidden')
+  }
+}
+
+export const createEndOfMonthReminderSelectors = (extensionOptions: ExtensionOptions) => {
+  const startTimeElement = document.getElementById('end-of-month-start-time') as HTMLInputElement
+  const dueTimeElement = document.getElementById('end-of-month-due-time') as HTMLInputElement
+
+  startTimeElement.value = convertTimeOnlyToInputTime(extensionOptions.endOfMonthReminderStartTime)
+  dueTimeElement.value = convertTimeOnlyToInputTime(extensionOptions.endOfMonthReminderDueTime)
+
+  startTimeElement.addEventListener('change', validate)
+  dueTimeElement.addEventListener('change', validate)
+}
+
+export const getEndOfMonthSelectedStartTime = (): TimeOnly => {
+  const timeElement = document.getElementById('end-of-month-start-time') as HTMLInputElement
+  return convertInputTimeToTimeOnly(timeElement.value)
+}
+
+export const getEndOfMonthSelectedDueTime = (): TimeOnly => {
+  const timeElement = document.getElementById('end-of-month-due-time') as HTMLInputElement
+  return convertInputTimeToTimeOnly(timeElement.value)
+}

--- a/extension/src/extension-options/end-of-week-reminder.ts
+++ b/extension/src/extension-options/end-of-week-reminder.ts
@@ -1,0 +1,82 @@
+import {
+  compareTimeOnly,
+  convertInputTimeToTimeOnly,
+  convertTimeOnlyToInputTime,
+  DayOfWeek,
+  TimeOnly,
+} from '../types/dates'
+import { ExtensionOptions } from '../types/extension-options'
+import { validator } from './validator'
+
+export const isValidTimes = (): boolean => {
+  const startTimeElement = document.getElementById('end-of-week-start-time') as HTMLInputElement
+  const dueTimeElement = document.getElementById('end-of-week-due-time') as HTMLInputElement
+
+  const startTime = convertInputTimeToTimeOnly(startTimeElement.value)
+  const dueTime = convertInputTimeToTimeOnly(dueTimeElement.value)
+
+  if (!startTime || !dueTime) {
+    return false
+  }
+  if (compareTimeOnly(dueTime, startTime) <= 0) {
+    return false
+  }
+
+  return true
+}
+
+const validate = () => {
+  const errorElement = document.getElementById('end-of-week-error') as HTMLDivElement
+
+  const validTimes = isValidTimes()
+  validator.setValid('end-of-week-reminder-times', isValidTimes())
+
+  if (validTimes) {
+    errorElement.classList.add('hidden')
+  } else {
+    errorElement.classList.remove('hidden')
+  }
+}
+
+export const createEndOfWeekReminderSelectors = (extensionOptions: ExtensionOptions) => {
+  const dayOfWeekElement = document.getElementById('end-of-week-day-of-week') as HTMLDivElement
+  const dayOfWeekButtons = dayOfWeekElement.querySelectorAll('button') as NodeListOf<HTMLButtonElement>
+  const startTimeElement = document.getElementById('end-of-week-start-time') as HTMLInputElement
+  const dueTimeElement = document.getElementById('end-of-week-due-time') as HTMLInputElement
+
+  dayOfWeekButtons.forEach((button) => {
+    const buttonDayOfWeek = button.getAttribute('data-day-of-week') as DayOfWeek
+
+    if (extensionOptions.endOfWeekReminderDayOfWeek === buttonDayOfWeek) {
+      button.classList.add('selected')
+    }
+
+    button.addEventListener('click', (e) => {
+      e.preventDefault()
+      dayOfWeekButtons.forEach((b) => b.classList.remove('selected'))
+      button.classList.add('selected')
+    })
+  })
+
+  startTimeElement.value = convertTimeOnlyToInputTime(extensionOptions.endOfWeekReminderStartTime)
+  dueTimeElement.value = convertTimeOnlyToInputTime(extensionOptions.endOfWeekReminderDueTime)
+
+  startTimeElement.addEventListener('change', validate)
+  dueTimeElement.addEventListener('change', validate)
+}
+
+export const getEndOfWeekReminderSelectedDayOfWeek = (): DayOfWeek => {
+  const dayOfWeekElement = document.getElementById('end-of-week-day-of-week') as HTMLDivElement
+  const selectedButton = dayOfWeekElement.querySelector('button.selected') as HTMLButtonElement
+  return selectedButton.getAttribute('data-day-of-week') as DayOfWeek
+}
+
+export const getEndOfWeekReminderSelectedStartTime = (): TimeOnly => {
+  const timeElement = document.getElementById('end-of-week-start-time') as HTMLInputElement
+  return convertInputTimeToTimeOnly(timeElement.value)
+}
+
+export const getEndOfWeekReminderSelectedDueTime = (): TimeOnly => {
+  const timeElement = document.getElementById('end-of-week-due-time') as HTMLInputElement
+  return convertInputTimeToTimeOnly(timeElement.value)
+}

--- a/extension/src/extension-options/extension-options.html
+++ b/extension/src/extension-options/extension-options.html
@@ -1,42 +1,135 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8" />
     <title>Clock Storm Settings</title>
   </head>
   <body>
     <form id="options">
-      <label class="row">
-        <p>Daily reminders</p>
+      <div id="tabs">
+        <a role="button" class="selected" data-tab="general"
+          ><i class="fa-solid fa-square-check"></i><span>General</span></a
+        >
+        <a role="button" data-tab="clock"><i class="fa-regular fa-clock"></i><span>Timing</span></a>
+        <a role="button" data-tab="alert"><i class="fa-regular fa-bell"></i><span>Alert</span></a>
+      </div>
 
-        <div class="checkbox-wrapper">
-          <input type="checkbox" id="daily-time-entry-reminder" />
-          <label for="daily-time-entry-reminder" class="toggle"><span></span></label>
+      <section data-tab="general">
+        <label class="row">
+          <p>Daily reminders</p>
+
+          <div class="checkbox-wrapper">
+            <input type="checkbox" id="daily-time-entry-reminder" />
+            <label for="daily-time-entry-reminder" class="toggle"><span></span></label>
+          </div>
+        </label>
+
+        <label class="row">
+          <p>End of week reminders</p>
+
+          <div class="checkbox-wrapper">
+            <input type="checkbox" id="end-of-week-timesheet-reminder" />
+            <label for="end-of-week-timesheet-reminder" class="toggle"><span></span></label>
+          </div>
+        </label>
+
+        <label class="row">
+          <p>End of month reminders (BETA)</p>
+
+          <div class="checkbox-wrapper">
+            <input type="checkbox" id="end-of-month-timesheet-reminder" />
+            <label for="end-of-month-timesheet-reminder" class="toggle"><span></span></label>
+          </div>
+        </label>
+      </section>
+
+      <section class="hidden" data-tab="clock">
+        <div id="clock-daily-reminder">
+          <p class="heading">Daily reminder</p>
+          <div id="daily-reminder-days" class="day-selector">
+            <button type="button" data-day-of-week="monday">Mon</button>
+            <button type="button" data-day-of-week="tuesday">Tue</button>
+            <button type="button" data-day-of-week="wednesday">Wed</button>
+            <button type="button" data-day-of-week="thursday">Thur</button>
+            <button type="button" data-day-of-week="friday">Fri</button>
+            <button type="button" data-day-of-week="saturday">Sat</button>
+            <button type="button" data-day-of-week="sunday">Sun</button>
+          </div>
+
+          <p id="daily-reminder-error" class="error hidden">Please select at least one day.</p>
+
+          <div class="time-selections">
+            <div class="time-selector">
+              <label>
+                <span>Start</span>
+                <input id="daily-reminder-start-time" type="time" value="09:00" />
+              </label>
+            </div>
+          </div>
         </div>
-      </label>
 
-      <label class="row">
-        <p>End of week reminders</p>
+        <div id="clock-end-of-week">
+          <p class="heading">End of week reminder</p>
 
-        <div class="checkbox-wrapper">
-          <input type="checkbox" id="end-of-week-timesheet-reminder" />
-          <label for="end-of-week-timesheet-reminder" class="toggle"><span></span></label>
+          <div id="end-of-week-day-of-week" class="day-selector">
+            <button type="button" data-day-of-week="monday">Mon</button>
+            <button type="button" data-day-of-week="tuesday">Tue</button>
+            <button type="button" data-day-of-week="wednesday">Wed</button>
+            <button type="button" data-day-of-week="thursday">Thur</button>
+            <button type="button" data-day-of-week="friday">Fri</button>
+            <button type="button" data-day-of-week="saturday">Sat</button>
+            <button type="button" data-day-of-week="sunday">Sun</button>
+          </div>
+
+          <div class="time-selections">
+            <div class="time-selector">
+              <label>
+                <span>Start</span>
+                <input id="end-of-week-start-time" type="time" value="09:00" />
+              </label>
+            </div>
+
+            <div class="time-selector">
+              <label>
+                <span>Due</span>
+                <input id="end-of-week-due-time" type="time" value="17:00" />
+              </label>
+            </div>
+          </div>
+
+          <p id="end-of-week-error" class="error hidden">The due time must be after the start time.</p>
         </div>
-      </label>
 
-      <label class="row">
-        <p>End of month reminders (BETA)</p>
+        <div id="clock-end-of-month">
+          <p class="heading">End of month reminder</p>
 
-        <div class="checkbox-wrapper">
-          <input type="checkbox" id="end-of-month-timesheet-reminder" />
-          <label for="end-of-month-timesheet-reminder" class="toggle"><span></span></label>
+          <div class="time-selections">
+            <div class="time-selector">
+              <label>
+                <span>Start</span>
+                <input id="end-of-month-start-time" type="time" value="09:00" />
+              </label>
+            </div>
+
+            <div class="time-selector">
+              <label>
+                <span>Due</span>
+                <input id="end-of-month-due-time" type="time" value="17:00" />
+              </label>
+            </div>
+          </div>
+
+          <p id="end-of-month-error" class="error hidden">The due time must be after the start time.</p>
         </div>
-      </label>
+      </section>
 
-      <p>Reminder icon</p>
-      <div id="gif-selector"></div>
+      <section class="hidden" data-tab="alert">
+        <p>Reminder icon</p>
+        <div id="gif-selector"></div>
 
-      <p>Reminder sound</p>
-      <div id="sound-selector"></div>
+        <p>Reminder sound</p>
+        <div id="sound-selector"></div>
+      </section>
 
       <div id="buttons">
         <input id="save" type="submit" value="Save" />

--- a/extension/src/extension-options/extension-options.scss
+++ b/extension/src/extension-options/extension-options.scss
@@ -25,6 +25,74 @@ label.row {
   cursor: pointer;
 }
 
+p {
+  &.heading {
+    margin-bottom: 10px;
+    font-weight: bold;
+  }
+
+  &.memo {
+    margin-top: 5px;
+    font-size: 11px;
+    color: rgb(97, 97, 97);
+  }
+}
+
+#tabs {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  margin-bottom: -1px;
+
+  a,
+  a:visited,
+  a:active {
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    font-family: Roboto, system-ui, sans-serif;
+    border-radius: 4px 4px 0 0;
+    color: rgb(26, 115, 232);
+    border-style: solid;
+    border-width: 1px;
+    border-color: rgb(218, 220, 224);
+    background-color: white;
+    padding: 8px 16px;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: bold;
+    margin-right: 12px;
+    box-sizing: border-box;
+    height: 34px;
+
+    span {
+      margin-left: 6px;
+    }
+
+    &:hover {
+      background-color: rgb(248, 250, 254);
+      border-color: rgb(210, 227, 252);
+    }
+
+    &.selected {
+      border-width: 1px 1px 0 1px;
+    }
+  }
+}
+
+section {
+  margin-bottom: 10px;
+  padding: 11px 10px 10px 10px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: rgb(218, 220, 224);
+  border-radius: 0 4px 4px 4px;
+
+  &.hidden {
+    display: none;
+  }
+}
+
 #gif-selector,
 #sound-selector {
   display: grid;
@@ -175,11 +243,18 @@ label.row {
   cursor: pointer;
   font-size: 13px;
   font-weight: bold;
-}
 
-#save:hover {
-  background-color: rgb(248, 250, 254);
-  border: 1px solid rgb(210, 227, 252);
+  &:hover {
+    background-color: rgb(248, 250, 254);
+    border: 1px solid rgb(210, 227, 252);
+  }
+
+  &:disabled {
+    cursor: default;
+    color: rgb(129, 134, 138);
+    background-color: white;
+    border: 1px solid rgb(241, 243, 244);
+  }
 }
 
 #version {
@@ -187,4 +262,202 @@ label.row {
   text-align: center;
   color: rgba(154, 153, 153, 0.7);
   font-style: italic;
+}
+
+.day-selector {
+  display: flex;
+  flex-direction: row;
+
+  button {
+    height: 60px;
+    border: 0;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    width: 14.2%;
+
+    color: rgb(26, 115, 232);
+    border-style: solid;
+    border-color: rgb(218, 220, 224);
+    border-width: 1px;
+    border-left-width: 0;
+    background-color: white;
+    padding: 0;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: bold;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+
+    &:hover {
+      background-color: rgb(248, 250, 254);
+      border-color: rgb(210, 227, 252);
+    }
+
+    &.selected {
+      background-color: rgb(237, 242, 252);
+    }
+
+    &:first-child {
+      border-radius: 4px 0 0 4px;
+      border-left-width: 1px;
+    }
+
+    &:last-child {
+      border-radius: 0 4px 4px 0;
+      border-right-width: 1px;
+    }
+  }
+}
+
+.time-selector {
+  display: flex;
+  align-items: center;
+
+  label {
+    display: flex;
+    align-items: center;
+
+    span {
+      font-size: 12px;
+      font-weight: bold;
+      margin-right: 10px;
+    }
+  }
+
+  input {
+    all: unset;
+    display: flex;
+    align-items: center;
+    border: 0;
+    font-family: Roboto, system-ui, sans-serif;
+    font-weight: bold;
+    font-size: 13px;
+
+    &,
+    &::-webkit-datetime-edit,
+    &::-webkit-datetime-edit-fields-wrapper {
+      width: 134px;
+      padding: 0;
+    }
+
+    &::-webkit-datetime-edit-hour-field,
+    &::-webkit-datetime-edit-minute-field,
+    &::-webkit-datetime-edit-ampm-field {
+      display: inline-flex;
+      box-sizing: border-box;
+      justify-content: center;
+      align-items: center;
+      color: rgb(26, 115, 232);
+      border-style: solid;
+      border-color: rgb(218, 220, 224);
+      border-width: 1px;
+      background-color: white;
+      border-radius: 4px;
+      padding: 0;
+      cursor: pointer;
+      font-size: 13px;
+      font-weight: bold;
+      width: 30px;
+
+      &:hover,
+      &:active,
+      &:focus {
+        background-color: rgb(248, 250, 254);
+        border-color: rgb(210, 227, 252);
+      }
+    }
+
+    &::-webkit-datetime-edit-hour-field,
+    &::-webkit-datetime-edit-minute-field,
+    &::-webkit-datetime-edit-ampm-field,
+    &::-webkit-calendar-picker-indicator {
+      height: 30px;
+    }
+
+    &::-webkit-datetime-edit-hour-field {
+      margin-right: 5px;
+    }
+
+    &::-webkit-datetime-edit-minute-field {
+      margin-left: 5px;
+    }
+
+    &::-webkit-datetime-edit-fields-wrapper {
+      display: flex;
+      align-items: center;
+    }
+
+    &::-webkit-datetime-edit-text {
+      white-space: normal;
+    }
+
+    &::-webkit-datetime-edit-ampm-field {
+      margin-left: 5px;
+    }
+
+    &::-webkit-calendar-picker-indicator {
+      padding: 0 5px;
+      margin: 0;
+      cursor: pointer;
+      background-position: center;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3C!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --%3E%3Cpath d='M256 0a256 256 0 1 0 0 512A256 256 0 1 0 256 0zM135 241c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l87 87 87-87c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9L273 345c-9.4 9.4-24.6 9.4-33.9 0L135 241z' fill='%231a73e8'/%3E%3C/svg%3E");
+    }
+
+    &::-webkit-clear-button {
+      display: none;
+    }
+  }
+}
+
+#weekly-due-date {
+  .day-selector {
+    margin-top: 10px;
+
+    button {
+      height: 30px;
+    }
+  }
+
+  .time-selector {
+    justify-content: flex-end;
+    margin-top: 5px;
+  }
+}
+
+.time-selections {
+  display: flex;
+  justify-content: space-between;
+}
+
+.day-selector {
+  margin-bottom: 5px;
+}
+
+.error {
+  color: red;
+  font-size: 12px;
+  text-align: center;
+
+  &.hidden {
+    display: none;
+  }
+}
+
+#clock-daily-reminder {
+  .error {
+    margin-bottom: 5px;
+  }
+}
+
+#clock-end-of-week,
+#clock-end-of-month {
+  .error {
+    margin-top: 5px;
+  }
+}
+
+#clock-daily-reminder,
+#clock-end-of-week {
+  margin-bottom: 10px;
 }

--- a/extension/src/extension-options/extension-options.ts
+++ b/extension/src/extension-options/extension-options.ts
@@ -1,8 +1,30 @@
+import '@fortawesome/fontawesome-free/scss/brands.scss'
+import '@fortawesome/fontawesome-free/scss/fontawesome.scss'
+import '@fortawesome/fontawesome-free/scss/regular.scss'
+import '@fortawesome/fontawesome-free/scss/solid.scss'
 import { ExtensionOptions } from '../types/extension-options'
+import {
+  createDailyReminderSelectors,
+  getDailyReminderSelectedDays,
+  getDailyReminderSelectedStartTime,
+} from './daily-reminder'
+import {
+  createEndOfMonthReminderSelectors,
+  getEndOfMonthSelectedDueTime,
+  getEndOfMonthSelectedStartTime,
+} from './end-of-month-reminder'
+import {
+  createEndOfWeekReminderSelectors,
+  getEndOfWeekReminderSelectedDayOfWeek,
+  getEndOfWeekReminderSelectedDueTime,
+  getEndOfWeekReminderSelectedStartTime,
+} from './end-of-week-reminder'
 import './extension-options.scss'
 import { createGifSelector, getSelectedGifUrl } from './gifs'
 import { createSoundSelector, getSelectedSoundUrl } from './sounds'
 import { getExtensionOptions } from './storage'
+import { createTabs } from './tabs'
+import { validator } from './validator'
 
 const main = async () => {
   const form = document.getElementById('options') as HTMLFormElement
@@ -19,8 +41,12 @@ const main = async () => {
 
   const extensionOptions = await getExtensionOptions()
 
+  createTabs()
   createGifSelector(extensionOptions)
   await createSoundSelector(extensionOptions)
+  createDailyReminderSelectors(extensionOptions)
+  createEndOfWeekReminderSelectors(extensionOptions)
+  createEndOfMonthReminderSelectors(extensionOptions)
 
   endOfWeekTimesheetReminder.checked = extensionOptions.endOfWeekTimesheetReminder
   dailyTimeEntryReminder.checked = extensionOptions.dailyTimeEntryReminder
@@ -28,6 +54,10 @@ const main = async () => {
 
   form.addEventListener('submit', async (event) => {
     event.preventDefault()
+
+    if (!validator.isValid()) {
+      return
+    }
 
     const soundDataUrl = await getSelectedSoundUrl(extensionOptions)
     const gifDataUrl = await getSelectedGifUrl(extensionOptions)
@@ -38,6 +68,13 @@ const main = async () => {
       endOfWeekTimesheetReminder: endOfWeekTimesheetReminder.checked,
       dailyTimeEntryReminder: dailyTimeEntryReminder.checked,
       endOfMonthTimesheetReminder: endOfMonthTimesheetReminder.checked,
+      dailyReminderDaysOfWeek: getDailyReminderSelectedDays(),
+      dailyReminderStartTime: getDailyReminderSelectedStartTime(),
+      endOfWeekReminderDayOfWeek: getEndOfWeekReminderSelectedDayOfWeek(),
+      endOfWeekReminderStartTime: getEndOfWeekReminderSelectedStartTime(),
+      endOfWeekReminderDueTime: getEndOfWeekReminderSelectedDueTime(),
+      endOfMonthReminderStartTime: getEndOfMonthSelectedStartTime(),
+      endOfMonthReminderDueTime: getEndOfMonthSelectedDueTime(),
     }
 
     await chrome.storage.local.set({

--- a/extension/src/extension-options/storage.ts
+++ b/extension/src/extension-options/storage.ts
@@ -2,17 +2,16 @@ import { ExtensionOptions } from '../types/extension-options'
 
 export const getExtensionOptions = async (): Promise<ExtensionOptions> => {
   const result = await chrome.storage.local.get(['extensionOptions'])
+
+  if (!result.extensionOptions) {
+    return ExtensionOptions.parse({})
+  }
+
   const parseResult = ExtensionOptions.safeParse(result.extensionOptions)
 
   if (parseResult.success) {
     return parseResult.data
   }
 
-  return {
-    soundDataUrl: 'sounds/cricket.wav',
-    gifDataUrl: 'gifs/clockstorm.gif',
-    endOfWeekTimesheetReminder: true,
-    dailyTimeEntryReminder: true,
-    endOfMonthTimesheetReminder: true,
-  }
+  return ExtensionOptions.parse({})
 }

--- a/extension/src/extension-options/tabs.ts
+++ b/extension/src/extension-options/tabs.ts
@@ -1,0 +1,31 @@
+export const createTabs = () => {
+  const tabs = document.getElementById('tabs') as HTMLDivElement
+  const tabSections = Array.from(document.querySelectorAll('section')) as HTMLElement[]
+  const tabLinks = Array.from(tabs.querySelectorAll('a')) as HTMLAnchorElement[]
+
+  for (const tabLink of tabLinks) {
+    tabLink.addEventListener('click', (event) => {
+      event.preventDefault()
+
+      const tabId = tabLink.getAttribute('data-tab') as string
+      const tabSection = document.querySelector(`section[data-tab=${tabId}]`) as HTMLElement
+      const tabLinkText = tabLink.querySelector('i') as HTMLElement
+
+      for (const tabSectionSingle of tabSections) {
+        tabSectionSingle.classList.add('hidden')
+      }
+
+      for (const tabLinkSingle of tabLinks) {
+        const tabLinkTextSingle = tabLinkSingle.querySelector('i') as HTMLElement
+        tabLinkTextSingle.classList.remove('fa-solid')
+        tabLinkTextSingle.classList.add('fa-regular')
+        tabLinkSingle.classList.remove('selected')
+      }
+
+      tabSection.classList.remove('hidden')
+      tabLinkText.classList.add('fa-solid')
+      tabLinkText.classList.remove('fa-regular')
+      tabLink.classList.add('selected')
+    })
+  }
+}

--- a/extension/src/extension-options/validator.ts
+++ b/extension/src/extension-options/validator.ts
@@ -1,0 +1,27 @@
+export type ValidatorElement = 'daily-reminder-days' | 'end-of-week-reminder-times' | 'end-of-month-reminder-times'
+
+const elements: Record<ValidatorElement, boolean> = {
+  'end-of-week-reminder-times': true,
+  'daily-reminder-days': true,
+  'end-of-month-reminder-times': true,
+}
+
+export interface Validator {
+  setValid: (element: ValidatorElement, isValid: boolean) => void
+  isValid: () => boolean
+}
+
+const onChange = () => {
+  const saveButton = document.getElementById('save') as HTMLButtonElement
+  saveButton.disabled = !validator.isValid()
+}
+
+export const validator: Validator = {
+  setValid: (element: ValidatorElement, isValid: boolean) => {
+    elements[element] = isValid
+    onChange()
+  },
+  isValid: () => {
+    return Object.values(elements).every((isValid) => isValid)
+  },
+}

--- a/extension/src/installation/helpers.ts
+++ b/extension/src/installation/helpers.ts
@@ -1,0 +1,19 @@
+import { compareDateOnly, DateOnly, getMondayOfDateOnly, getTodayDateOnly, minusDays } from '../types/dates'
+import { getInstallationDate } from './storage'
+
+export const getEveryMondaySinceInstallation = async (): Promise<DateOnly[]> => {
+  const installationDate = await getInstallationDate()
+  const installationWeekMonday = getMondayOfDateOnly(installationDate)
+
+  let dateOnly = getTodayDateOnly()
+
+  const mondays: DateOnly[] = []
+
+  while (compareDateOnly(dateOnly, installationWeekMonday) >= 0) {
+    const monday = getMondayOfDateOnly(dateOnly)
+    mondays.push(monday)
+    dateOnly = minusDays(dateOnly, 7)
+  }
+
+  return mondays
+}

--- a/extension/src/installation/storage.ts
+++ b/extension/src/installation/storage.ts
@@ -1,0 +1,31 @@
+import { DateOnly, getTodayDateOnly } from '../types/dates'
+
+const installationDateKey = 'installationDate'
+
+const setInstallationDate = async (date: DateOnly): Promise<void> => {
+  const data: { [key: string]: any } = {}
+  data[installationDateKey] = date
+  await chrome.storage.local.set(data)
+}
+
+export const getInstallationDate = async (): Promise<DateOnly> => {
+  const result = await chrome.storage.local.get([installationDateKey])
+
+  const fallback = async (): Promise<DateOnly> => {
+    const today = getTodayDateOnly()
+    await setInstallationDate(today)
+    return today
+  }
+
+  if (!result[installationDateKey]) {
+    return await fallback()
+  }
+
+  const parseResult = DateOnly.safeParse(result[installationDateKey])
+
+  if (parseResult.success) {
+    return parseResult.data
+  }
+
+  return await fallback()
+}

--- a/extension/src/notifications/notifications.ts
+++ b/extension/src/notifications/notifications.ts
@@ -1,55 +1,172 @@
-import { getExtensionOptions } from '../extension-options/storage'
+import { getEveryMondaySinceInstallation } from '../installation/helpers'
 import { getTimeSheet } from '../time-sheets/storage'
 import { summarizeTimeSheet } from '../time-sheets/summary'
 import {
+  compareDateOnly,
+  compareTimeOnly,
+  DateOnly,
   DayOfWeek,
-  dayOfWeekIndexes,
-  getAllDaysPriorInWeek,
-  getDayOfWeek,
-  getMondayOfDateOnly,
+  daysOfWeek,
+  getTimeOnly,
   getTodayDateOnly,
+  TimeOnly,
 } from '../types/dates'
+import { ExtensionOptions } from '../types/extension-options'
+import { TimeSheet, TimeSheetSummary } from '../types/time-sheet'
 
-export type NotificationType = 'daily' | 'weekly' | 'monthly'
+export interface DailyNotificationType {
+  type: 'daily'
+  dayOfWeek: DayOfWeek
+}
 
-export const getActiveNotificationTypes = async (): Promise<NotificationType[]> => {
-  const today = getTodayDateOnly()
-  const dayOfWeek = getDayOfWeek(today)
-  const monday = getMondayOfDateOnly(today)
-  const timeSheet = await getTimeSheet(monday)
-  const summary = summarizeTimeSheet(timeSheet)
-  const daysPrior = getAllDaysPriorInWeek(dayOfWeek, true, true)
-  const extensionOptions = await getExtensionOptions()
-  const dayOfWeekIndex = dayOfWeekIndexes[dayOfWeek]
-  const dueDayOfWeek: DayOfWeek = 'thursday'
-  const dueDayOfWeekIndex = dayOfWeekIndexes[dueDayOfWeek]
+export interface EndOfWeekNotificationType {
+  type: 'end-of-week'
+}
 
-  const results: NotificationType[] = []
+export interface EndOfMonthNotificationType {
+  type: 'end-of-month'
+}
 
-  for (const dayPrior of daysPrior) {
-    if (
-      (extensionOptions.dailyTimeEntryReminder && !summary.daysFilled[dayPrior]) ||
-      summary.weekStatus === 'some-unsaved'
-    ) {
-      results.push('daily')
-      break
-    }
+export type NotificationType = DailyNotificationType | EndOfWeekNotificationType | EndOfMonthNotificationType
+
+const isPastDueStartTime = (today: DateOnly, time: TimeOnly, dueDate: DateOnly, dueStartTime: TimeOnly): boolean => {
+  const dateOnlyCompare = compareDateOnly(today, dueDate)
+
+  if (dateOnlyCompare < 0) {
+    return false
+  }
+
+  if (dateOnlyCompare === 0 && compareTimeOnly(time, dueStartTime) < 0) {
+    return false
+  }
+
+  return true
+}
+
+const shouldRemindForDaily = (
+  today: DateOnly,
+  time: TimeOnly,
+  dailyDayOfWeek: DayOfWeek,
+  extensionOptions: ExtensionOptions,
+  timeSheet: TimeSheet,
+  summary: TimeSheetSummary,
+): boolean => {
+  if (!extensionOptions.dailyTimeEntryReminder || !extensionOptions.dailyReminderDaysOfWeek.includes(dailyDayOfWeek)) {
+    return false
+  }
+
+  if (summary.daysFilled[dailyDayOfWeek] && summary.weekStatus !== 'some-unsaved') {
+    return false
+  }
+
+  if (!isPastDueStartTime(today, time, timeSheet.dates[dailyDayOfWeek], extensionOptions.dailyReminderStartTime)) {
+    return false
+  }
+
+  return true
+}
+
+const shouldRemindForEndOfWeek = (
+  today: DateOnly,
+  time: TimeOnly,
+  extensionOptions: ExtensionOptions,
+  timeSheet: TimeSheet,
+  summary: TimeSheetSummary,
+): boolean => {
+  if (!extensionOptions.endOfWeekTimesheetReminder) {
+    return false
+  }
+
+  if (summary.weekStatus === 'all-submitted-or-approved') {
+    return false
   }
 
   if (
-    extensionOptions.endOfWeekTimesheetReminder &&
-    dayOfWeekIndex >= dueDayOfWeekIndex &&
-    summary.weekStatus !== 'all-submitted-or-approved'
+    !isPastDueStartTime(
+      today,
+      time,
+      timeSheet.dates[extensionOptions.endOfWeekReminderDayOfWeek],
+      extensionOptions.endOfWeekReminderStartTime,
+    )
   ) {
-    results.push('weekly')
+    return false
   }
 
-  if (summary.alertableLastDayOfMonth && extensionOptions.endOfMonthTimesheetReminder) {
-    const alertableLastDayOfMonthIndex = dayOfWeekIndexes[summary.alertableLastDayOfMonth]
-    if (dayOfWeekIndex >= alertableLastDayOfMonthIndex && summary.weekStatus !== 'all-submitted-or-approved') {
-      results.push('monthly')
+  return true
+}
+
+const shouldRemindForEndOfMonth = (
+  today: DateOnly,
+  time: TimeOnly,
+  extensionOptions: ExtensionOptions,
+  summary: TimeSheetSummary,
+): boolean => {
+  if (!extensionOptions.endOfMonthTimesheetReminder) {
+    return false
+  }
+
+  if (!summary.endOfMonthReminderDate) {
+    return false
+  }
+
+  // TODO: It might be nice to check only the parts of the time sheet that are related to the days leading up to the end of month due date.
+  if (summary.weekStatus === 'all-submitted-or-approved') {
+    return false
+  }
+
+  if (!isPastDueStartTime(today, time, summary.endOfMonthReminderDate, extensionOptions.endOfMonthReminderStartTime)) {
+    return false
+  }
+
+  return true
+}
+
+export const getActiveNotificationTypes = async (
+  timeSheet: TimeSheet,
+  summary: TimeSheetSummary,
+  extensionOptions: ExtensionOptions,
+): Promise<NotificationType[]> => {
+  const today = getTodayDateOnly()
+  const timeOnly = getTimeOnly()
+
+  const results: NotificationType[] = []
+
+  for (const dailyDayOfWeek of daysOfWeek) {
+    if (shouldRemindForDaily(today, timeOnly, dailyDayOfWeek, extensionOptions, timeSheet, summary)) {
+      results.push({
+        type: 'daily',
+        dayOfWeek: dailyDayOfWeek,
+      })
     }
   }
 
+  if (shouldRemindForEndOfWeek(today, timeOnly, extensionOptions, timeSheet, summary)) {
+    results.push({
+      type: 'end-of-week',
+    })
+  }
+
+  if (shouldRemindForEndOfMonth(today, timeOnly, extensionOptions, summary)) {
+    results.push({
+      type: 'end-of-month',
+    })
+  }
+
   return results
+}
+
+export const checkShouldNotify = async (extensionOptions: ExtensionOptions): Promise<boolean> => {
+  const mondays = await getEveryMondaySinceInstallation()
+
+  for (const monday of mondays) {
+    const timeSheet = await getTimeSheet(monday)
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
+    const activeNotificationTypes = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
+
+    if (activeNotificationTypes.length > 0) {
+      return true
+    }
+  }
+
+  return false
 }

--- a/extension/src/popup/indicators.ts
+++ b/extension/src/popup/indicators.ts
@@ -1,0 +1,43 @@
+import { getActiveNotificationTypes } from '../notifications/notifications'
+import { getTimeSheet } from '../time-sheets/storage'
+import { summarizeTimeSheet } from '../time-sheets/summary'
+import { DateOnly } from '../types/dates'
+import { ExtensionOptions } from '../types/extension-options'
+
+type Direction = 'previous' | 'next'
+
+export const checkShouldIndicatePreviousOrNextWeekReminders = async (
+  mondays: DateOnly[],
+  currentMondayIndex: number,
+  direction: Direction,
+  extensionOptions: ExtensionOptions,
+): Promise<boolean> => {
+  let mondayIndex = direction === 'previous' ? currentMondayIndex + 1 : currentMondayIndex - 1
+
+  const boundaryCheck = (index: number) => {
+    if (direction === 'previous') {
+      return index < mondays.length
+    } else {
+      return index >= 0
+    }
+  }
+
+  while (boundaryCheck(mondayIndex)) {
+    const monday = mondays[mondayIndex]
+    const timeSheet = await getTimeSheet(monday)
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
+    const activeNotificationTypes = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
+
+    if (activeNotificationTypes.length > 0) {
+      return true
+    }
+
+    if (direction === 'previous') {
+      mondayIndex++
+    } else {
+      mondayIndex--
+    }
+  }
+
+  return false
+}

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -7,59 +7,90 @@
   </head>
   <body>
     <div id="popup">
-      <div id="summary" class="hidden">
-        <h2>Time Sheet Summary</h2>
+      <div id="week-selector" class="hidden">
+        <a role="button" data-week-direction="previous"
+          ><span class="notification"></span><i class="fa-solid fa-square-caret-left"></i
+          ><i class="fa-regular fa-square-caret-left"></i
+        ></a>
+        <span id="week-selector-date"></span>
+        <a role="button" data-week-direction="next"
+          ><span class="notification"></span><i class="fa-solid fa-square-caret-right"></i
+          ><i class="fa-regular fa-square-caret-right"></i
+        ></a>
+      </div>
+      <div id="container">
+        <div id="summary" class="hidden">
+          <h2>Time Sheet Summary</h2>
 
-        <div class="row">
-          <div class="left">
-            <img src="images/logo32.png" alt="Clock Storm" />
-          </div>
-          <div class="right">
-            <p><span id="timecard-days-saved" class="timecard-dynamic-value"></span> days saved</p>
-            <p><span id="timecard-days-submitted" class="timecard-dynamic-value"></span> days submitted</p>
-            <p>
-              <span id="timecard-time-left" class="timecard-dynamic-value"></span> time left to finish your time cards!
-            </p>
+          <div class="row">
+            <div class="left">
+              <img src="images/logo32.png" alt="Clock Storm" />
+            </div>
+            <div class="right">
+              <p><span id="timecard-days-saved" class="timecard-dynamic-value"></span> days saved</p>
+              <p><span id="timecard-days-submitted" class="timecard-dynamic-value"></span> days submitted</p>
+              <p id="timecard-time-left-wrapper">
+                <span id="timecard-time-left" class="timecard-dynamic-value"></span> time left to finish your time
+                cards!
+              </p>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div id="active-notifications" class="hidden">
-        <h2>Active Notifications</h2>
-        <div class="row">
-          <div class="left">
-            <i class="status fa-solid fa-triangle-exclamation"></i>
+        <div id="active-notifications" class="hidden">
+          <h2>Active Notifications</h2>
+          <div class="row">
+            <div class="left">
+              <i class="status fa-solid fa-triangle-exclamation"></i>
+            </div>
+            <div class="right">
+              <ul></ul>
+            </div>
           </div>
-          <div class="right">
-            <ul></ul>
-          </div>
+          <p>To clear your active notification, navigate to your time sheet and proceed.</p>
         </div>
-        <p>To clear your active notification, navigate to your time sheet and proceed.</p>
-      </div>
 
-      <div id="loading">
-        <p><i class="fa-solid fa-spinner fa-spin" title="Loading"></i></p>
-      </div>
+        <div id="loading">
+          <p><i class="fa-solid fa-spinner fa-spin" title="Loading"></i></p>
+        </div>
 
-      <div id="links">
-        <p class="settings">
-          <a href="#" id="settings-link" title="Settings"><i class="fa-solid fa-gear"></i></a>
-        </p>
-        <p class="guide">
-          <a href="https://www.clockstorm.com/#guide" title="User Guide" target="_blank"><i class="fa-solid fa-book"></i></a>
-        </p>
-        <p class="github">
-          <a href="https://github.com/clockstorm/clockstorm" title="GitHub" target="_blank"><i class="fa-brands fa-github"></i></a>
-        </p>
-        <p class="bug">
-          <a href="https://github.com/ClockStorm/clockstorm/issues/new?template=bug_report.md" title="Bug Report" target="_blank"><i class="fa-solid fa-bug"></i></a>
-        </p>
-        <p class="idea">
-          <a href="https://github.com/ClockStorm/clockstorm/issues/new?template=feature_request.md" title="Feature Request" target="_blank"><i class="fa-solid fa-lightbulb"></i></a>
-        </p>
-        <p class="discord">
-          <a href="https://discord.com/invite/xSmDZGcZjd" title="Discord" target="_blank"><i class="fa-brands fa-discord"></i></a>
-        </p>
+        <div id="links">
+          <p class="settings">
+            <a href="#" id="settings-link" title="Settings"><i class="fa-solid fa-gear"></i></a>
+          </p>
+          <p class="guide">
+            <a href="https://www.clockstorm.com/#guide" title="User Guide" target="_blank"
+              ><i class="fa-solid fa-book"></i
+            ></a>
+          </p>
+          <p class="github">
+            <a href="https://github.com/clockstorm/clockstorm" title="GitHub" target="_blank"
+              ><i class="fa-brands fa-github"></i
+            ></a>
+          </p>
+          <p class="bug">
+            <a
+              href="https://github.com/ClockStorm/clockstorm/issues/new?template=bug_report.md"
+              title="Bug Report"
+              target="_blank"
+              ><i class="fa-solid fa-bug"></i
+            ></a>
+          </p>
+          <p class="idea">
+            <a
+              href="https://github.com/ClockStorm/clockstorm/issues/new?template=feature_request.md"
+              title="Feature Request"
+              target="_blank"
+              ><i class="fa-solid fa-lightbulb"></i
+            ></a>
+          </p>
+          <p class="discord">
+            <a href="https://discord.com/invite/xSmDZGcZjd" title="Discord" target="_blank"
+              ><i class="fa-brands fa-discord"></i
+            ></a>
+          </p>
+        </div>
+      </div>
     </div>
   </body>
 </html>

--- a/extension/src/popup/popup.scss
+++ b/extension/src/popup/popup.scss
@@ -2,7 +2,6 @@
 
 body {
   width: 400px;
-  margin: 8px;
   line-height: 2em;
 }
 
@@ -17,6 +16,10 @@ label,
 span,
 li {
   font-family: Roboto, system-ui, sans-serif;
+}
+
+#container {
+  padding: 8px;
 }
 
 #summary,
@@ -56,6 +59,71 @@ li {
   display: none;
 }
 
+#week-selector {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  background-color: black;
+  padding: 8px;
+
+  #week-selector-date {
+    font-size: 14px;
+    font-weight: bold;
+    color: white;
+  }
+
+  a {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 24px;
+    color: white;
+    position: relative;
+
+    .notification {
+      position: absolute;
+      top: -3px;
+      right: -3px;
+      background-color: red;
+      border-radius: 8px;
+      width: 8px;
+      height: 8px;
+      display: none;
+    }
+
+    &.has-notification {
+      .notification {
+        display: block;
+      }
+    }
+
+    .fa-regular {
+      display: inline-block;
+    }
+
+    .fa-solid {
+      display: none;
+    }
+
+    &.disabled {
+      opacity: 0;
+      cursor: default;
+    }
+
+    &:hover {
+      .fa-regular {
+        display: none;
+      }
+
+      .fa-solid {
+        display: inline-block;
+      }
+    }
+  }
+}
 #active-notifications {
   margin-top: 10px;
 

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -1,40 +1,113 @@
 import '@fortawesome/fontawesome-free/scss/brands.scss'
 import '@fortawesome/fontawesome-free/scss/fontawesome.scss'
 import '@fortawesome/fontawesome-free/scss/solid.scss'
+import { getEveryMondaySinceInstallation } from '@src/installation/helpers'
+import { CancelSetIntervalAsyncFn, setIntervalAsync } from '../background-tasks/background-task'
+import { getExtensionOptions } from '../extension-options/storage'
 import { getActiveNotificationTypes } from '../notifications/notifications'
 import { getTimeSheet } from '../time-sheets/storage'
 import { summarizeTimeSheet } from '../time-sheets/summary'
-import { getMondayOfDateOnly, getTodayDateOnly } from '../types/dates'
-import { waitFor } from '../utils/utils'
+import { DateOnly, addDays, compareDateOnly, getDisplayDayOfWeek } from '../types/dates'
+import { checkShouldIndicatePreviousOrNextWeekReminders } from './indicators'
 import './popup.scss'
 
 const main = async () => {
   const daysSubmittedElement = document.getElementById('timecard-days-submitted') as HTMLSpanElement
   const daysSavedElement = document.getElementById('timecard-days-saved') as HTMLSpanElement
+  const timeLeftWrapperElement = document.getElementById('timecard-time-left-wrapper') as HTMLDivElement
   const timeLeftElement = document.getElementById('timecard-time-left') as HTMLSpanElement
   const loadingElement = document.getElementById('loading') as HTMLDivElement
   const summaryElement = document.getElementById('summary') as HTMLDivElement
   const activeNotificationsElement = document.getElementById('active-notifications') as HTMLParagraphElement
   const activeNotificationsListElement = document.querySelector('#active-notifications ul') as HTMLUListElement
   const settingsLinkElement = document.getElementById('settings-link') as HTMLAnchorElement
+  const dateSelector = document.getElementById('week-selector') as HTMLDivElement
+  const dateSelectorDateElement = dateSelector.querySelector('#week-selector-date') as HTMLSpanElement
+  const previousButtonElement = dateSelector.querySelector('a[data-week-direction="previous"]') as HTMLButtonElement
+  const nextButtonElement = dateSelector.querySelector('a[data-week-direction="next"]') as HTMLButtonElement
 
   settingsLinkElement.addEventListener('click', (e) => {
     e.preventDefault()
     chrome.runtime.openOptionsPage()
   })
 
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const today = getTodayDateOnly()
-    const monday = getMondayOfDateOnly(today)
+  const initialMondays = await getEveryMondaySinceInstallation()
+  let currentMonday: DateOnly = initialMondays[0]
+
+  const getCurrentMondayIndex = (mondays: DateOnly[]): number => {
+    const currentMondayIndex = mondays.findIndex((monday) => compareDateOnly(monday, currentMonday) === 0)
+
+    if (currentMondayIndex === -1) {
+      throw new Error('Current Monday not found in list of mondays')
+    }
+
+    return currentMondayIndex
+  }
+
+  const updateUI = async () => {
+    const extensionOptions = await getExtensionOptions()
+    const mondays = await getEveryMondaySinceInstallation()
+    const currentMondayIndex = getCurrentMondayIndex(mondays)
+
+    if (currentMondayIndex === 0) {
+      timeLeftWrapperElement.classList.remove('hidden')
+    } else {
+      timeLeftWrapperElement.classList.add('hidden')
+    }
+
+    if (currentMondayIndex === 0) {
+      nextButtonElement.classList.add('disabled')
+    } else {
+      nextButtonElement.classList.remove('disabled')
+
+      // Check if the next weeks have any active alerts
+      const shouldIndicateNext = await checkShouldIndicatePreviousOrNextWeekReminders(
+        mondays,
+        currentMondayIndex,
+        'next',
+        extensionOptions,
+      )
+
+      console.log('shouldIndicateNext', shouldIndicateNext)
+
+      if (shouldIndicateNext) {
+        nextButtonElement.classList.add('has-notification')
+      } else {
+        nextButtonElement.classList.remove('has-notification')
+      }
+    }
+
+    if (currentMondayIndex === mondays.length - 1) {
+      previousButtonElement.classList.add('disabled')
+    } else {
+      previousButtonElement.classList.remove('disabled')
+
+      // Check if the previous weeks have any active alerts
+      const shouldIndicatePrevious = await checkShouldIndicatePreviousOrNextWeekReminders(
+        mondays,
+        currentMondayIndex,
+        'previous',
+        extensionOptions,
+      )
+
+      if (shouldIndicatePrevious) {
+        previousButtonElement.classList.add('has-notification')
+      } else {
+        previousButtonElement.classList.remove('has-notification')
+      }
+    }
+
+    const monday = mondays[currentMondayIndex]
+    const sunday = addDays(monday, 6)
+    dateSelectorDateElement.innerText = `${monday.month}/${monday.day}/${monday.year} to ${sunday.month}/${sunday.day}/${sunday.year}`
     const timeSheet = await getTimeSheet(monday)
-    const summary = summarizeTimeSheet(timeSheet)
+    const summary = summarizeTimeSheet(timeSheet, extensionOptions)
 
     daysSubmittedElement.innerHTML = summary.totalDaysSubmitted.toString(10)
     daysSavedElement.innerHTML = summary.totalDaysSaved.toString(10)
     timeLeftElement.innerHTML = summary.timeRemaining
 
-    const activeNotificationTypes = await getActiveNotificationTypes()
+    const activeNotificationTypes = await getActiveNotificationTypes(timeSheet, summary, extensionOptions)
 
     if (activeNotificationTypes.length > 0) {
       activeNotificationsElement.classList.remove('hidden')
@@ -44,12 +117,12 @@ const main = async () => {
 
     const activeNotificationsListTextPieces = activeNotificationTypes
       .map((type) => {
-        switch (type) {
+        switch (type.type) {
           case 'daily':
-            return 'Daily reminder'
-          case 'weekly':
+            return `Daily reminder (${getDisplayDayOfWeek(type.dayOfWeek)})`
+          case 'end-of-week':
             return 'End of week reminder'
-          case 'monthly':
+          case 'end-of-month':
             return 'End of month reminder'
           default:
             return null
@@ -66,9 +139,53 @@ const main = async () => {
 
     summaryElement.classList.remove('hidden')
     loadingElement.classList.add('hidden')
-
-    await waitFor(1000)
   }
+
+  let stopAutoRefresh: CancelSetIntervalAsyncFn | null = null
+
+  const manualUpdateUI = async () => {
+    if (stopAutoRefresh !== null) {
+      stopAutoRefresh()
+      stopAutoRefresh = null
+    }
+
+    await updateUI()
+
+    stopAutoRefresh = setIntervalAsync(async () => {
+      await updateUI()
+      return true
+    }, 1000)
+  }
+
+  previousButtonElement.addEventListener('click', async (e) => {
+    e.preventDefault()
+    const mondays = await getEveryMondaySinceInstallation()
+    let currentMondayIndex = getCurrentMondayIndex(mondays)
+    currentMondayIndex++
+
+    if (currentMondayIndex >= mondays.length) {
+      currentMondayIndex = mondays.length - 1
+    }
+
+    currentMonday = mondays[currentMondayIndex]
+    await manualUpdateUI()
+  })
+
+  nextButtonElement.addEventListener('click', async (e) => {
+    e.preventDefault()
+    const mondays = await getEveryMondaySinceInstallation()
+    let currentMondayIndex = getCurrentMondayIndex(mondays)
+    currentMondayIndex--
+
+    if (currentMondayIndex < 0) {
+      currentMondayIndex = 0
+    }
+
+    currentMonday = mondays[currentMondayIndex]
+    await manualUpdateUI()
+  })
+
+  await manualUpdateUI()
 }
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/extension/src/service-worker.ts
+++ b/extension/src/service-worker.ts
@@ -2,7 +2,7 @@ import { animatedIcon } from './background-tasks/animated-icon'
 import { executeBackgroundTask } from './background-tasks/background-task'
 import { getExtensionOptions } from './extension-options/storage'
 import { GIFStream, parseGIF } from './gifs/gifs'
-import { getActiveNotificationTypes } from './notifications/notifications'
+import { checkShouldNotify } from './notifications/notifications'
 import { playAudio, stopAudio } from './offscreen/offscreen'
 import { GIF } from './types/gifs'
 import { waitFor } from './utils/utils'
@@ -28,9 +28,6 @@ const main = async () => {
   while (true) {
     await waitFor(50)
 
-    const activeNotificationTypes = await getActiveNotificationTypes()
-    const shouldNotify = activeNotificationTypes.length > 0
-
     const cancelSound = async () => {
       if (soundPlayingId) {
         await stopAudio(soundPlayingId)
@@ -48,6 +45,7 @@ const main = async () => {
 
     let newGifLoaded = false
     const extensionOptions = await getExtensionOptions()
+    const shouldNotify = await checkShouldNotify(extensionOptions)
 
     if (extensionOptions.gifDataUrl !== lastGifDataUrl) {
       lastGifDataUrl = extensionOptions.gifDataUrl

--- a/extension/src/time-sheets/storage.ts
+++ b/extension/src/time-sheets/storage.ts
@@ -1,15 +1,11 @@
 import { addDays, DateOnly, toDateOnlyKey } from '../types/dates'
-import { isTimeSheet, TimeSheet } from '../types/time-sheet'
+import { TimeSheet } from '../types/time-sheet'
 
 export const getTimeSheet = async (weekMondayDate: DateOnly): Promise<TimeSheet> => {
   const key = `timesheet-${toDateOnlyKey(weekMondayDate)}`
   const result = await chrome.storage.local.get([key])
 
-  if (result[key] && isTimeSheet(result[key])) {
-    return result[key]
-  }
-
-  return {
+  const fallbackTimeSheet = TimeSheet.parse({
     dates: {
       monday: weekMondayDate,
       tuesday: addDays(weekMondayDate, 1),
@@ -20,5 +16,17 @@ export const getTimeSheet = async (weekMondayDate: DateOnly): Promise<TimeSheet>
       sunday: addDays(weekMondayDate, 6),
     },
     timeCards: [],
+  })
+
+  if (!result[key]) {
+    return fallbackTimeSheet
   }
+
+  const parseResult = TimeSheet.safeParse(result[key])
+
+  if (parseResult.success) {
+    return parseResult.data
+  }
+
+  return fallbackTimeSheet
 }

--- a/extension/src/types/extension-options.ts
+++ b/extension/src/types/extension-options.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { DayOfWeek, TimeOnly } from './dates'
 
 export const ExtensionOptions = z.object({
   endOfWeekTimesheetReminder: z.boolean().default(true),
@@ -6,5 +7,28 @@ export const ExtensionOptions = z.object({
   endOfMonthTimesheetReminder: z.boolean().default(true),
   soundDataUrl: z.string().default('sounds/cricket.wav'),
   gifDataUrl: z.string().default('gifs/clockstorm.gif'),
+  dailyReminderDaysOfWeek: z.array(DayOfWeek).default(['monday', 'tuesday', 'wednesday', 'thursday', 'friday']),
+  dailyReminderStartTime: TimeOnly.default({
+    hour: 9,
+    minute: 0,
+  }),
+  endOfWeekReminderDayOfWeek: DayOfWeek.default('thursday'),
+  endOfWeekReminderStartTime: TimeOnly.default({
+    hour: 9,
+    minute: 0,
+  }),
+  endOfWeekReminderDueTime: TimeOnly.default({
+    hour: 17,
+    minute: 0,
+  }),
+  endOfMonthReminderStartTime: TimeOnly.default({
+    hour: 9,
+    minute: 0,
+  }),
+  endOfMonthReminderDueTime: TimeOnly.default({
+    hour: 17,
+    minute: 0,
+  }),
 })
+
 export type ExtensionOptions = z.infer<typeof ExtensionOptions>

--- a/extension/src/types/time-sheet.ts
+++ b/extension/src/types/time-sheet.ts
@@ -1,6 +1,6 @@
 import equal from 'fast-deep-equal'
 import { z } from 'zod'
-import { DateOnly, DayOfWeek } from './dates'
+import { DateOnly } from './dates'
 
 export const TimeCardStatus = z.union([
   z.literal('submitted'),
@@ -66,8 +66,6 @@ export interface DaysFilled {
   sunday: boolean
 }
 
-export const isTimeSheet = (input: any): input is TimeSheet => TimeSheet.safeParse(input).success
-
 export const isTimeSheetEqual = (first: TimeSheet | null, second: TimeSheet | null) => {
   return equal(first, second)
 }
@@ -78,5 +76,5 @@ export interface TimeSheetSummary {
   totalDaysSubmitted: number
   totalDaysSaved: number
   timeRemaining: string
-  alertableLastDayOfMonth: DayOfWeek | null
+  endOfMonthReminderDate: DateOnly | null
 }

--- a/website/src/components/app.tsx
+++ b/website/src/components/app.tsx
@@ -1,9 +1,9 @@
-import { GuidePage } from '@src/pages/guide'
-import { HomePage } from '@src/pages/home'
-import { PrivacyPage } from '@src/pages/privacy'
 import React from 'react'
 import { Route } from 'react-router'
 import { HashRouter, Link, Switch } from 'react-router-dom'
+import { GuidePage } from '../pages/guide'
+import { HomePage } from '../pages/home'
+import { PrivacyPage } from '../pages/privacy'
 import './app.scss'
 
 const Application: React.FC = () => {


### PR DESCRIPTION
### Added

- Support for setting daily reminder days of the week and start time for reminders.
- Support for setting end of week reminder due date and time, as well as start time for reminders.
- Support for setting end of week reminder due time, as well as start time for reminders.
- Users can now browse their time sheet summary for past weeks.

### Changed

- Options screen is now split up into tabs: "General", "Timing", "Alert".
- Reminders will occur for previous weeks of missing time sheet information (bounded by the installation date of the extension).

This fixes #11 and #18