### PR TITLE
Custom time picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Options screen is now split up into tabs: "General", "Timing", "Alert".
 - Reminders will occur for previous weeks of missing time sheet information (bounded by the installation date of the extension).
 
+### Fixed
+
+- Styling issues of time pickers caused by recent Chrome update.
+
 ## [1.1.0] - 2023-03-29
 
 ### Added

--- a/extension/src/extension-options/daily-reminder.ts
+++ b/extension/src/extension-options/daily-reminder.ts
@@ -1,5 +1,6 @@
-import { convertInputTimeToTimeOnly, convertTimeOnlyToInputTime, DayOfWeek, TimeOnly } from '@src/types/dates'
-import { ExtensionOptions } from '@src/types/extension-options'
+import { convertInputTimeToTimeOnly, convertTimeOnlyToInputTime, DayOfWeek, TimeOnly } from '../types/dates'
+import { ExtensionOptions } from '../types/extension-options'
+import { createTimePicker } from './time-picker'
 import { validator } from './validator'
 
 const validate = () => {
@@ -18,7 +19,7 @@ const validate = () => {
 export const createDailyReminderSelectors = (extensionOptions: ExtensionOptions) => {
   const daysElement = document.getElementById('daily-reminder-days') as HTMLDivElement
   const dayButtons = daysElement.querySelectorAll('button') as NodeListOf<HTMLButtonElement>
-  const startTimeElement = document.getElementById('daily-reminder-start-time') as HTMLInputElement
+  const startTimeElement = createTimePicker(document.getElementById('daily-reminder-start-time') as HTMLDivElement)
 
   dayButtons.forEach((button) => {
     const buttonDayOfWeek = button.getAttribute('data-day-of-week') as DayOfWeek
@@ -34,7 +35,7 @@ export const createDailyReminderSelectors = (extensionOptions: ExtensionOptions)
     })
   })
 
-  startTimeElement.value = convertTimeOnlyToInputTime(extensionOptions.dailyReminderStartTime)
+  startTimeElement.setValue(convertTimeOnlyToInputTime(extensionOptions.dailyReminderStartTime))
 }
 
 export const getDailyReminderSelectedDays = (): DayOfWeek[] => {
@@ -44,6 +45,6 @@ export const getDailyReminderSelectedDays = (): DayOfWeek[] => {
 }
 
 export const getDailyReminderSelectedStartTime = (): TimeOnly => {
-  const timeElement = document.getElementById('daily-reminder-start-time') as HTMLInputElement
-  return convertInputTimeToTimeOnly(timeElement.value)
+  const timeElement = createTimePicker(document.getElementById('daily-reminder-start-time') as HTMLDivElement)
+  return convertInputTimeToTimeOnly(timeElement.getValue())
 }

--- a/extension/src/extension-options/end-of-month-reminder.ts
+++ b/extension/src/extension-options/end-of-month-reminder.ts
@@ -1,13 +1,14 @@
 import { compareTimeOnly, convertInputTimeToTimeOnly, convertTimeOnlyToInputTime, TimeOnly } from '@src/types/dates'
 import { ExtensionOptions } from '@src/types/extension-options'
+import { createTimePicker } from './time-picker'
 import { validator } from './validator'
 
 export const isValidTimes = (): boolean => {
-  const startTimeElement = document.getElementById('end-of-month-start-time') as HTMLInputElement
-  const dueTimeElement = document.getElementById('end-of-month-due-time') as HTMLInputElement
+  const startTimeElement = createTimePicker(document.getElementById('end-of-month-start-time') as HTMLDivElement)
+  const dueTimeElement = createTimePicker(document.getElementById('end-of-month-due-time') as HTMLDivElement)
 
-  const startTime = convertInputTimeToTimeOnly(startTimeElement.value)
-  const dueTime = convertInputTimeToTimeOnly(dueTimeElement.value)
+  const startTime = convertInputTimeToTimeOnly(startTimeElement.getValue())
+  const dueTime = convertInputTimeToTimeOnly(dueTimeElement.getValue())
 
   if (!startTime || !dueTime) {
     return false
@@ -34,22 +35,22 @@ const validate = () => {
 }
 
 export const createEndOfMonthReminderSelectors = (extensionOptions: ExtensionOptions) => {
-  const startTimeElement = document.getElementById('end-of-month-start-time') as HTMLInputElement
-  const dueTimeElement = document.getElementById('end-of-month-due-time') as HTMLInputElement
+  const startTimeElement = createTimePicker(document.getElementById('end-of-month-start-time') as HTMLDivElement)
+  const dueTimeElement = createTimePicker(document.getElementById('end-of-month-due-time') as HTMLDivElement)
 
-  startTimeElement.value = convertTimeOnlyToInputTime(extensionOptions.endOfMonthReminderStartTime)
-  dueTimeElement.value = convertTimeOnlyToInputTime(extensionOptions.endOfMonthReminderDueTime)
+  startTimeElement.setValue(convertTimeOnlyToInputTime(extensionOptions.endOfMonthReminderStartTime))
+  dueTimeElement.setValue(convertTimeOnlyToInputTime(extensionOptions.endOfMonthReminderDueTime))
 
-  startTimeElement.addEventListener('change', validate)
-  dueTimeElement.addEventListener('change', validate)
+  startTimeElement.addChangeListener(validate)
+  dueTimeElement.addChangeListener(validate)
 }
 
 export const getEndOfMonthSelectedStartTime = (): TimeOnly => {
-  const timeElement = document.getElementById('end-of-month-start-time') as HTMLInputElement
-  return convertInputTimeToTimeOnly(timeElement.value)
+  const timeElement = createTimePicker(document.getElementById('end-of-month-start-time') as HTMLDivElement)
+  return convertInputTimeToTimeOnly(timeElement.getValue())
 }
 
 export const getEndOfMonthSelectedDueTime = (): TimeOnly => {
-  const timeElement = document.getElementById('end-of-month-due-time') as HTMLInputElement
-  return convertInputTimeToTimeOnly(timeElement.value)
+  const timeElement = createTimePicker(document.getElementById('end-of-month-due-time') as HTMLDivElement)
+  return convertInputTimeToTimeOnly(timeElement.getValue())
 }

--- a/extension/src/extension-options/end-of-week-reminder.ts
+++ b/extension/src/extension-options/end-of-week-reminder.ts
@@ -6,14 +6,15 @@ import {
   TimeOnly,
 } from '../types/dates'
 import { ExtensionOptions } from '../types/extension-options'
+import { createTimePicker } from './time-picker'
 import { validator } from './validator'
 
 export const isValidTimes = (): boolean => {
-  const startTimeElement = document.getElementById('end-of-week-start-time') as HTMLInputElement
-  const dueTimeElement = document.getElementById('end-of-week-due-time') as HTMLInputElement
+  const startTimeElement = createTimePicker(document.getElementById('end-of-week-start-time') as HTMLDivElement)
+  const dueTimeElement = createTimePicker(document.getElementById('end-of-week-due-time') as HTMLDivElement)
 
-  const startTime = convertInputTimeToTimeOnly(startTimeElement.value)
-  const dueTime = convertInputTimeToTimeOnly(dueTimeElement.value)
+  const startTime = convertInputTimeToTimeOnly(startTimeElement.getValue())
+  const dueTime = convertInputTimeToTimeOnly(dueTimeElement.getValue())
 
   if (!startTime || !dueTime) {
     return false
@@ -41,8 +42,8 @@ const validate = () => {
 export const createEndOfWeekReminderSelectors = (extensionOptions: ExtensionOptions) => {
   const dayOfWeekElement = document.getElementById('end-of-week-day-of-week') as HTMLDivElement
   const dayOfWeekButtons = dayOfWeekElement.querySelectorAll('button') as NodeListOf<HTMLButtonElement>
-  const startTimeElement = document.getElementById('end-of-week-start-time') as HTMLInputElement
-  const dueTimeElement = document.getElementById('end-of-week-due-time') as HTMLInputElement
+  const startTimeElement = createTimePicker(document.getElementById('end-of-week-start-time') as HTMLDivElement)
+  const dueTimeElement = createTimePicker(document.getElementById('end-of-week-due-time') as HTMLDivElement)
 
   dayOfWeekButtons.forEach((button) => {
     const buttonDayOfWeek = button.getAttribute('data-day-of-week') as DayOfWeek
@@ -58,11 +59,11 @@ export const createEndOfWeekReminderSelectors = (extensionOptions: ExtensionOpti
     })
   })
 
-  startTimeElement.value = convertTimeOnlyToInputTime(extensionOptions.endOfWeekReminderStartTime)
-  dueTimeElement.value = convertTimeOnlyToInputTime(extensionOptions.endOfWeekReminderDueTime)
+  startTimeElement.setValue(convertTimeOnlyToInputTime(extensionOptions.endOfWeekReminderStartTime))
+  dueTimeElement.setValue(convertTimeOnlyToInputTime(extensionOptions.endOfWeekReminderDueTime))
 
-  startTimeElement.addEventListener('change', validate)
-  dueTimeElement.addEventListener('change', validate)
+  startTimeElement.addChangeListener(validate)
+  dueTimeElement.addChangeListener(validate)
 }
 
 export const getEndOfWeekReminderSelectedDayOfWeek = (): DayOfWeek => {
@@ -72,11 +73,11 @@ export const getEndOfWeekReminderSelectedDayOfWeek = (): DayOfWeek => {
 }
 
 export const getEndOfWeekReminderSelectedStartTime = (): TimeOnly => {
-  const timeElement = document.getElementById('end-of-week-start-time') as HTMLInputElement
-  return convertInputTimeToTimeOnly(timeElement.value)
+  const timeElement = createTimePicker(document.getElementById('end-of-week-start-time') as HTMLDivElement)
+  return convertInputTimeToTimeOnly(timeElement.getValue())
 }
 
 export const getEndOfWeekReminderSelectedDueTime = (): TimeOnly => {
-  const timeElement = document.getElementById('end-of-week-due-time') as HTMLInputElement
-  return convertInputTimeToTimeOnly(timeElement.value)
+  const timeElement = createTimePicker(document.getElementById('end-of-week-due-time') as HTMLDivElement)
+  return convertInputTimeToTimeOnly(timeElement.getValue())
 }

--- a/extension/src/extension-options/extension-options.html
+++ b/extension/src/extension-options/extension-options.html
@@ -60,10 +60,19 @@
 
           <div class="time-selections">
             <div class="time-selector">
-              <label>
-                <span>Start</span>
-                <input id="daily-reminder-start-time" type="time" value="09:00" />
-              </label>
+              <div class="time-selector-label">
+                <span class="label-text">Start</span>
+
+                <div id="daily-reminder-start-time" class="time-picker-input">
+                  <input class="hour-selector" type="text" data-default-value="09" />
+                  <span>:</span>
+                  <input class="minute-selector" type="text" data-default-value="00" />
+                  <div class="am-pm-selector">
+                    <button type="button" class="selected" data-am-pm="am">AM</button>
+                    <button type="button" data-am-pm="pm">PM</button>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -83,17 +92,33 @@
 
           <div class="time-selections">
             <div class="time-selector">
-              <label>
-                <span>Start</span>
-                <input id="end-of-week-start-time" type="time" value="09:00" />
-              </label>
+              <div class="time-selector-label">
+                <span class="label-text">Start</span>
+                <div id="end-of-week-start-time" class="time-picker-input">
+                  <input class="hour-selector" type="text" data-default-value="09" />
+                  <span>:</span>
+                  <input class="minute-selector" type="text" data-default-value="00" />
+                  <div class="am-pm-selector">
+                    <button type="button" class="selected" data-am-pm="am">AM</button>
+                    <button type="button" data-am-pm="pm">PM</button>
+                  </div>
+                </div>
+              </div>
             </div>
 
             <div class="time-selector">
-              <label>
-                <span>Due</span>
-                <input id="end-of-week-due-time" type="time" value="17:00" />
-              </label>
+              <div class="time-selector-label">
+                <span class="label-text">Due</span>
+                <div id="end-of-week-due-time" class="time-picker-input">
+                  <input class="hour-selector" type="text" data-default-value="05" />
+                  <span>:</span>
+                  <input class="minute-selector" type="text" data-default-value="00" />
+                  <div class="am-pm-selector">
+                    <button type="button" data-am-pm="am">AM</button>
+                    <button type="button" class="selected" data-am-pm="pm">PM</button>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
 
@@ -105,17 +130,33 @@
 
           <div class="time-selections">
             <div class="time-selector">
-              <label>
-                <span>Start</span>
-                <input id="end-of-month-start-time" type="time" value="09:00" />
-              </label>
+              <div class="time-selector-label">
+                <span class="label-text">Start</span>
+                <div id="end-of-month-start-time" class="time-picker-input">
+                  <input class="hour-selector" type="text" data-default-value="09" />
+                  <span>:</span>
+                  <input class="minute-selector" type="text" data-default-value="00" />
+                  <div class="am-pm-selector">
+                    <button type="button" class="selected" data-am-pm="am">AM</button>
+                    <button type="button" data-am-pm="pm">PM</button>
+                  </div>
+                </div>
+              </div>
             </div>
 
             <div class="time-selector">
-              <label>
-                <span>Due</span>
-                <input id="end-of-month-due-time" type="time" value="17:00" />
-              </label>
+              <div class="time-selector-label">
+                <span class="label-text">Due</span>
+                <div id="end-of-month-due-time" class="time-picker-input">
+                  <input class="hour-selector" type="text" data-default-value="05" />
+                  <span>:</span>
+                  <input class="minute-selector" type="text" data-default-value="00" />
+                  <div class="am-pm-selector">
+                    <button type="button" data-am-pm="am">AM</button>
+                    <button type="button" class="selected" data-am-pm="pm">PM</button>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
 

--- a/extension/src/extension-options/extension-options.scss
+++ b/extension/src/extension-options/extension-options.scss
@@ -314,40 +314,29 @@ section {
   display: flex;
   align-items: center;
 
-  label {
+  .time-selector-label {
     display: flex;
     align-items: center;
 
-    span {
+    .label-text {
       font-size: 12px;
       font-weight: bold;
       margin-right: 10px;
+      font-family: Roboto, system-ui, sans-serif;
     }
   }
 
-  input {
-    all: unset;
+  .time-picker-input {
     display: flex;
     align-items: center;
-    border: 0;
     font-family: Roboto, system-ui, sans-serif;
     font-weight: bold;
     font-size: 13px;
+    height: 30px;
 
-    &,
-    &::-webkit-datetime-edit,
-    &::-webkit-datetime-edit-fields-wrapper {
-      width: 134px;
-      padding: 0;
-    }
-
-    &::-webkit-datetime-edit-hour-field,
-    &::-webkit-datetime-edit-minute-field,
-    &::-webkit-datetime-edit-ampm-field {
-      display: inline-flex;
+    .hour-selector,
+    .minute-selector {
       box-sizing: border-box;
-      justify-content: center;
-      align-items: center;
       color: rgb(26, 115, 232);
       border-style: solid;
       border-color: rgb(218, 220, 224);
@@ -359,53 +348,69 @@ section {
       font-size: 13px;
       font-weight: bold;
       width: 30px;
+      height: 30px;
+      text-align: center;
+      outline: none;
 
       &:hover,
-      &:active,
-      &:focus {
+      &:focus,
+      &:active {
         background-color: rgb(248, 250, 254);
         border-color: rgb(210, 227, 252);
       }
     }
 
-    &::-webkit-datetime-edit-hour-field,
-    &::-webkit-datetime-edit-minute-field,
-    &::-webkit-datetime-edit-ampm-field,
-    &::-webkit-calendar-picker-indicator {
-      height: 30px;
-    }
-
-    &::-webkit-datetime-edit-hour-field {
+    .hour-selector {
       margin-right: 5px;
     }
 
-    &::-webkit-datetime-edit-minute-field {
+    .minute-selector {
       margin-left: 5px;
     }
 
-    &::-webkit-datetime-edit-fields-wrapper {
+    .am-pm-selector {
+      margin-left: 5px;
       display: flex;
-      align-items: center;
-    }
+      flex-direction: column;
 
-    &::-webkit-datetime-edit-text {
-      white-space: normal;
-    }
+      button {
+        height: 15px;
+        border: 0;
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        width: 30px;
+        color: rgb(26, 115, 232);
+        border-style: solid;
+        border-color: rgb(218, 220, 224);
+        border-width: 1px;
+        background-color: white;
+        padding: 0;
+        cursor: pointer;
+        font-size: 11px;
+        font-weight: bold;
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
 
-    &::-webkit-datetime-edit-ampm-field {
-      margin-left: 5px;
-    }
+        &:hover {
+          background-color: rgb(248, 250, 254);
+          border-color: rgb(210, 227, 252);
+        }
 
-    &::-webkit-calendar-picker-indicator {
-      padding: 0 5px;
-      margin: 0;
-      cursor: pointer;
-      background-position: center;
-      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3C!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --%3E%3Cpath d='M256 0a256 256 0 1 0 0 512A256 256 0 1 0 256 0zM135 241c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l87 87 87-87c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9L273 345c-9.4 9.4-24.6 9.4-33.9 0L135 241z' fill='%231a73e8'/%3E%3C/svg%3E");
-    }
+        &.selected {
+          background-color: rgb(237, 242, 252);
+        }
 
-    &::-webkit-clear-button {
-      display: none;
+        &:first-child {
+          border-radius: 4px 4px 0 0;
+          border-bottom-width: 0.5px;
+        }
+
+        &:last-child {
+          border-radius: 0 0 4px 4px;
+          border-top-width: 0.5px;
+        }
+      }
     }
   }
 }

--- a/extension/src/extension-options/time-picker.ts
+++ b/extension/src/extension-options/time-picker.ts
@@ -1,0 +1,148 @@
+type TimePickerChangeListener = (value: string) => void
+
+interface GetTimePickerInputAPI {
+  getValue: () => string
+  setValue: (value: string) => void
+  addChangeListener: (listener: TimePickerChangeListener) => void
+}
+
+export const createTimePicker = (container: HTMLElement): GetTimePickerInputAPI => {
+  if ((container as any)['getTimePickerInputAPI']) {
+    return (container as any)['getTimePickerInputAPI']
+  }
+
+  const hourSelectorElement = container.querySelector('.hour-selector') as HTMLInputElement
+  const minuteSelectorElement = container.querySelector('.minute-selector') as HTMLInputElement
+  const amPmSelectorElement = container.querySelector('.am-pm-selector') as HTMLDivElement
+  const amPmButtonElements = amPmSelectorElement.querySelectorAll('button') as NodeListOf<HTMLButtonElement>
+  const listeners: TimePickerChangeListener[] = []
+
+  const isValidValue = (value: string) => {
+    return /^(01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23):[0-5][0-9]$/.test(value)
+  }
+
+  const getValue = () => {
+    const hour = hourSelectorElement.value
+    const hourNumber = parseInt(hour, 10)
+    const minute = minuteSelectorElement.value
+    const amPm = amPmButtonElements[0].classList.contains('selected') ? 'am' : 'pm'
+
+    let adjustedHour = hour
+
+    if (amPm === 'am' && hourNumber === 12) {
+      adjustedHour = '00'
+    } else if (amPm === 'pm' && hourNumber !== 12) {
+      adjustedHour = (hourNumber + 12).toString()
+    }
+
+    const value = `${adjustedHour}:${minute}`
+    return value
+  }
+
+  const isValidHour = (hour: string) => {
+    const hourNumber = parseInt(hour, 10)
+    return !isNaN(hourNumber) && hourNumber >= 1 && hourNumber <= 12
+  }
+
+  const sanitizeHour = () => {
+    const isValid = isValidHour(hourSelectorElement.value)
+
+    if (!isValid) {
+      hourSelectorElement.value = hourSelectorElement.getAttribute('data-default-value') as string
+      onChange()
+    }
+
+    const hour = parseInt(hourSelectorElement.value, 10)
+    hourSelectorElement.value = hour.toString().padStart(2, '0')
+    onChange()
+  }
+
+  hourSelectorElement.addEventListener('blur', () => {
+    sanitizeHour()
+  })
+
+  const onChange = () => {
+    const value = getValue()
+
+    if (!isValidValue(value)) {
+      return
+    }
+
+    for (const listener of listeners) {
+      listener(value)
+    }
+  }
+
+  const isValidMinute = (minute: string) => {
+    const minuteNumber = parseInt(minute, 10)
+    return !isNaN(minuteNumber) && minuteNumber >= 0 && minuteNumber <= 59
+  }
+
+  const sanitizeMinute = () => {
+    const isValid = isValidMinute(minuteSelectorElement.value)
+
+    if (!isValid) {
+      minuteSelectorElement.value = minuteSelectorElement.getAttribute('data-default-value') as string
+      onChange()
+    }
+
+    const minute = parseInt(minuteSelectorElement.value, 10)
+    minuteSelectorElement.value = minute.toString().padStart(2, '0')
+    onChange()
+  }
+
+  minuteSelectorElement.addEventListener('blur', () => {
+    sanitizeMinute()
+  })
+
+  sanitizeHour()
+  sanitizeMinute()
+
+  hourSelectorElement.addEventListener('change', onChange)
+  minuteSelectorElement.addEventListener('change', onChange)
+
+  for (const amPmButtonElement of amPmButtonElements) {
+    amPmButtonElement.addEventListener('click', () => {
+      for (const button of amPmButtonElements) {
+        button.classList.remove('selected')
+      }
+
+      amPmButtonElement.classList.add('selected')
+      onChange()
+    })
+  }
+
+  const api = {
+    getValue,
+    setValue: (value: string) => {
+      const [hour, minute] = value.split(':')
+      const hourNumber = parseInt(hour, 10)
+
+      let adjustedHour = hour
+
+      if (hourNumber === 0) {
+        adjustedHour = '12'
+      } else if (hourNumber > 12) {
+        adjustedHour = (hourNumber - 12).toString().padStart(2, '0')
+      }
+
+      hourSelectorElement.value = adjustedHour
+      minuteSelectorElement.value = minute.padStart(2, '0')
+
+      if (hourNumber >= 12) {
+        amPmButtonElements[1].classList.add('selected')
+        amPmButtonElements[0].classList.remove('selected')
+      } else {
+        amPmButtonElements[0].classList.add('selected')
+        amPmButtonElements[1].classList.remove('selected')
+      }
+    },
+    addChangeListener: (listener: TimePickerChangeListener) => {
+      listeners.push(listener)
+    },
+  }
+
+  ;(container as any)['getTimePickerInputAPI'] = api
+
+  return api
+}


### PR DESCRIPTION
Recently Google Chrome was updated, and it has limited our ability to style the necessary shadow DOM components. This commit swaps out the HTML5 time input with a custom version that we can easily style.